### PR TITLE
Add MkDocs Material docs site with auto-publish

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: docs
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          if [ -f requirements-docs.txt ]; then
+            pip install -r requirements-docs.txt
+          else
+            pip install mkdocs mkdocs-material pymdown-extensions
+          fi
+      - name: Build
+        run: mkdocs build --clean
+      - name: Deploy
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -147,3 +147,10 @@ Logs are emitted in JSON-friendly format, making them CloudWatch-ready. Adjust l
 - Linting and unit tests can be wired into GitHub Actions as part of CI/CD.
 - `temp_data/` retains every raw response; purge periodically if storage becomes large.
 - Contributions should include updates to this README when adding new functionality.
+
+## Documentation
+
+Published with MkDocs Material (auto-deployed from `main`):
+https://<your-github-username>.github.io/releasecopilot-ai
+
+Edit pages under `docs/` and push to `main` — the site republish is automated by GitHub Actions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture Overview
+
+This page narrates the key components of **releasecopilot-ai** and links to live Mermaid diagrams.
+
+- **System Context**: High-level ecosystem and integrations
+- **Components**: Internal modules and data flow between them
+- **Data Flow**: End-to-end audit sequence (CLI/UI → Jira/Bitbucket → Export)
+- **AWS Deployment**: Infra layout with Lambda/ECS, S3, Secrets Manager, IAM
+- **Agents**: Future orchestration (LangGraph/crewAI), MCP memory, RAG search
+
+Navigate via the left sidebar to see each diagram.

--- a/docs/diagrams/agents.md
+++ b/docs/diagrams/agents.md
@@ -1,0 +1,35 @@
+# Agent Orchestration
+
+```mermaid
+flowchart TB
+  subgraph Orchestrator
+    Plan[Planner / TaskGraph]
+    Tools[Tooling Layer]
+  end
+
+  subgraph Agents
+    A1[Jira Agent]
+    A2[Bitbucket Agent]
+    A3[Audit Agent]
+    A4[Reporting Agent]
+  end
+
+  subgraph Memory & RAG
+    MCP[MCP Memory]
+    VDB[FAISS / Vertex AI]
+  end
+
+  User[User/CLI/UI] --> Plan
+  Plan --> A1
+  Plan --> A2
+  A1 --> Tools
+  A2 --> Tools
+  Tools -->|Jira API| JiraCloud[(Jira)]
+  Tools -->|Bitbucket API| BBCloud[(Bitbucket)]
+  A3 --> Plan
+  A3 --> MCP
+  A3 --> VDB
+  A4 --> MCP
+  A4 --> VDB
+  Plan --> Output[Excel / JSON / UI]
+```

--- a/docs/diagrams/components.md
+++ b/docs/diagrams/components.md
@@ -1,0 +1,58 @@
+# Components
+
+```mermaid
+flowchart TB
+  subgraph CLI Layer
+    CLI[cli/main.py]
+    Config[config loader]
+  end
+
+  subgraph Core Domain
+    Orchestrator[orchestrator.py]
+    Matcher[matcher/engine.py]
+    Exporter[export/exporter.py]
+    Cache[cache/store.py]
+    Logging[logging/config.py]
+  end
+
+  subgraph Integrations
+    JiraClient[clients/jira_client.py]
+    BBClient[clients/bitbucket_client.py]
+    SecretsClient[clients/secrets_manager_client.py]
+  end
+
+  subgraph Agents & Memory
+    Agents[agents/ (LangGraph or crewAI)]
+    MCP[MCP memory connectors]
+    RAG[RAG: FAISS/Vertex AI]
+  end
+
+  subgraph Deployment
+    Lambda[Lambda handler]
+    ECS[ECS task runner]
+    S3[(S3)]
+    GHActions[GitHub Actions CI]
+  end
+
+  CLI --> Orchestrator
+  Config --> Orchestrator
+  Orchestrator --> JiraClient
+  Orchestrator --> BBClient
+  Orchestrator --> Matcher
+  Matcher --> Exporter
+  Orchestrator --> Exporter
+  Orchestrator --> Cache
+  Logging -. used by .- CLI
+  Logging -. used by .- Orchestrator
+  SecretsClient --> JiraClient
+  SecretsClient --> BBClient
+
+  Orchestrator --> Agents
+  Agents --> MCP
+  Agents --> RAG
+
+  GHActions --> S3
+  Lambda --> Orchestrator
+  ECS --> Orchestrator
+  Exporter --> S3
+```

--- a/docs/diagrams/data-flow.md
+++ b/docs/diagrams/data-flow.md
@@ -1,0 +1,34 @@
+# End-to-End Data Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant CLI as CLI / Streamlit UI
+  participant OR as Orchestrator
+  participant JC as Jira Client
+  participant BC as Bitbucket Client
+  participant M as Matcher
+  participant EX as Exporter
+  participant S3 as S3
+  participant SEC as Secrets Manager
+
+  U->>CLI: Start audit (project, fixVersion, date window)
+  CLI->>OR: Run(params)
+  OR->>SEC: Fetch OAuth & API creds
+  SEC-->>OR: Credentials
+
+  OR->>JC: fetch_issues_by_jql(jql)
+  JC-->>OR: issues[]
+
+  OR->>BC: fetch_commits(repos, branches, dateRange)
+  BC-->>OR: commits[]
+
+  OR->>M: match(issues[], commits[])
+  M-->>OR: matched, missingStories, orphanCommits, summary
+
+  OR->>EX: export(matched, missing, orphans, summary)
+  EX-->>CLI: audit_results.xlsx, audit_results.json
+  EX->>S3: upload artifacts
+
+  CLI-->>U: Show summary + download links
+```

--- a/docs/diagrams/deployment-aws.md
+++ b/docs/diagrams/deployment-aws.md
@@ -1,0 +1,36 @@
+# AWS Deployment
+
+```mermaid
+flowchart LR
+  subgraph VPC[VPC]
+    subgraph PrivateSubnets[Private Subnets]
+      ECS[ECS/Fargate Task]:::svc
+      Lmb[Lambda]:::svc
+    end
+    subgraph PublicSubnets[Public Subnets]
+      ALB[ALB / API Gateway]:::edge
+    end
+  end
+
+  Dev[GitHub Actions CI]:::ext -->|build/test| ECR[ECR]:::aws
+  Dev -->|IaC apply| CFN[CloudFormation/Terraform/CDK]:::aws
+  CFN --> VPC
+  CFN --> Secrets[Secrets Manager]:::aws
+  CFN --> S3[(S3 Reports)]:::aws
+  CFN --> Logs[CloudWatch Logs]:::aws
+  CFN --> IAM[IAM Roles/Policies]:::aws
+
+  ALB --> ECS
+  ALB --> Lmb
+  ECS --> Secrets
+  Lmb --> Secrets
+  ECS --> S3
+  Lmb --> S3
+  ECS --> Logs
+  Lmb --> Logs
+
+  classDef aws fill:#eef7ff,stroke:#2f6feb,color:#0b2e5a
+  classDef svc fill:#fff8e6,stroke:#b26a00,color:#4a2c00
+  classDef edge fill:#e6fffb,stroke:#0aa, color:#044
+  classDef ext fill:#f0f0f0,stroke:#888,color:#333
+```

--- a/docs/diagrams/system-context.md
+++ b/docs/diagrams/system-context.md
@@ -1,0 +1,30 @@
+# System Context
+
+```mermaid
+flowchart LR
+  User([Engineer / RM / DevOps]) -->|Run audit, view reports| UI[Web UI (Streamlit)]
+  User -->|CLI usage| CLI[CLI Tool]
+
+  subgraph ReleaseCopilot-AI
+    CLI --> Core[Audit Core]
+    UI --> Core
+    Core --> Jira[Jira Client (OAuth 3LO)]
+    Core --> BB[Bitbucket Client]
+    Core --> Match[Story↔Commit Matcher]
+    Core --> Export[Exporter (Excel/JSON)]
+    Core --> Agents[Agents (LangGraph/crewAI)]
+    Agents --> MCP[MCP Memory Layer]
+  end
+
+  subgraph AWS
+    Core --> S3[(S3 Reports/Artifacts)]
+    Core --> Secrets[Secrets Manager]
+    Depl[Lambda/ECS Task] --> Core
+  end
+
+  Jira <--> |REST v3| JiraCloud[(Jira Cloud)]
+  BB <--> |REST| BitbucketCloud[(Bitbucket Cloud)]
+
+  Export --> |Download| UI
+  S3 --> |Download links| UI
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+<script>
+  if (window.mermaid) { mermaid.initialize({ startOnLoad: true }); }
+</script>
+# releasecopilot-ai Docs
+
+Welcome! This site documents the architecture and implementation details for **releasecopilot-ai**, a modular, AWS-deployable AI release audit tool that integrates with Jira and Bitbucket, with future Agent + RAG capabilities.
+
+- Start with **Architecture → Overview** for a guided tour.
+- Diagrams are authored in Mermaid and rendered live.
+
+## Local Preview
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements-docs.txt || pip install mkdocs mkdocs-material pymdown-extensions
+mkdocs serve
+```
+Open the URL printed in the terminal (usually http://127.0.0.1:8000).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,30 @@
+site_name: releasecopilot-ai
+theme:
+  name: material
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - attr_list
+  - tables
+  - md_in_html
+  - pymdownx.snippets
+  - pymdownx.highlight
+  - footnotes
+  - toc:
+      permalink: true
+
+extra_javascript:
+  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+
+nav:
+  - Home: index.md
+  - Architecture:
+      - Overview: architecture.md
+      - System Context: diagrams/system-context.md
+      - Components: diagrams/components.md
+      - Data Flow: diagrams/data-flow.md
+      - AWS Deployment: diagrams/deployment-aws.md
+      - Agents: diagrams/agents.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.39
+pymdown-extensions==10.11.2


### PR DESCRIPTION
## Summary
- add MkDocs Material configuration with Mermaid support and new documentation structure
- create architecture and diagram pages for releasecopilot-ai
- configure GitHub Actions workflow to build and deploy docs to GitHub Pages on pushes to main and update README with documentation links

## Testing
- mkdocs build --clean

------
https://chatgpt.com/codex/tasks/task_e_68c9e1d5503c832fac96b6bb9aa5daf7