### PR TITLE
Implement layered configuration merging with AWS secret fallback

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,0 +1,23 @@
+# CLI Usage
+
+The Release Copilot CLI accepts configuration from YAML files, environment variables, and direct flags. Configuration precedence is:
+
+1. Command line arguments (highest priority)
+2. Environment variables
+3. YAML defaults (`releasecopilot.yaml`)
+
+Secrets follow the same order, and when `--use-aws-secrets-manager` is provided the CLI falls back to AWS Secrets Manager for any missing values. Secrets retrieved from AWS are cached so that each key is only fetched once per run.
+
+## Running the CLI
+
+```bash
+python main.py --config releasecopilot.yaml --fix-version 2025.09.27
+```
+
+Any CLI flag can override both environment variables and YAML defaults. For example, set `JIRA_BASE` in your environment but override it for a one-off run using `--jira-base`.
+
+## Providing Secrets
+
+Provide secrets through CLI flags (e.g., `--jira-token`, `--bitbucket-token`) or matching environment variables (`JIRA_TOKEN`, `BITBUCKET_TOKEN`). If a secret is still missing and AWS fallback is enabled, Release Copilot will request the value from AWS Secrets Manager using the same key name.
+
+To enable the fallback, pass `--use-aws-secrets-manager` or set the environment variable `USE_AWS_SECRETS_MANAGER=true`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src .
+testpaths = tests

--- a/src/releasecopilot/__init__.py
+++ b/src/releasecopilot/__init__.py
@@ -1,0 +1,3 @@
+"""Release Copilot package."""
+
+__all__ = ["config", "aws_secrets", "cli"]

--- a/src/releasecopilot/aws_secrets.py
+++ b/src/releasecopilot/aws_secrets.py
@@ -1,0 +1,50 @@
+"""Minimal AWS Secrets Manager helper."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:  # pragma: no cover - boto3 is an optional dependency at test time
+    boto3 = None  # type: ignore[assignment]
+    BotoCoreError = ClientError = Exception  # type: ignore[assignment]
+
+
+@lru_cache(maxsize=None)
+def _client():  # pragma: no cover - exercised via get_secret
+    if boto3 is None:  # pragma: no cover - defensive; boto3 is expected
+        raise RuntimeError("boto3 is required to access AWS Secrets Manager")
+    return boto3.client("secretsmanager")
+
+
+@lru_cache(maxsize=None)
+def get_secret(name: str) -> Optional[str]:
+    """Fetch ``name`` from AWS Secrets Manager, caching the result."""
+
+    if not name:
+        return None
+
+    try:
+        client = _client()
+    except Exception:  # pragma: no cover - client creation errors are propagated
+        return None
+
+    try:
+        response = client.get_secret_value(SecretId=name)
+    except (ClientError, BotoCoreError):
+        return None
+
+    secret = response.get("SecretString")
+    if secret is not None:
+        return secret
+
+    binary_secret = response.get("SecretBinary")
+    if isinstance(binary_secret, (bytes, bytearray)):
+        try:
+            return binary_secret.decode("utf-8")
+        except Exception:  # pragma: no cover - unexpected encoding issues
+            return None
+
+    return None

--- a/src/releasecopilot/cli.py
+++ b/src/releasecopilot/cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for Release Copilot configuration."""
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Optional
+
+from .config import build_config
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Release Copilot configuration")
+    parser.add_argument(
+        "--config",
+        help="Path to a releasecopilot.yaml file (defaults to ./releasecopilot.yaml if present)",
+    )
+    parser.add_argument("--fix-version", dest="fix_version", help="Fix version to operate on")
+    parser.add_argument(
+        "--jira-base",
+        dest="jira_base",
+        help="Base URL of the Jira instance (e.g. https://example.atlassian.net)",
+    )
+    parser.add_argument(
+        "--bitbucket-base",
+        dest="bitbucket_base",
+        help="Base URL of the Bitbucket workspace",
+    )
+    parser.add_argument("--jira-user", dest="jira_user", help="Jira username or email")
+    parser.add_argument("--jira-token", dest="jira_token", help="Jira API token or password")
+    parser.add_argument(
+        "--bitbucket-token",
+        dest="bitbucket_token",
+        help="Bitbucket access token or app password",
+    )
+    parser.add_argument(
+        "--use-aws-secrets-manager",
+        dest="use_aws_secrets_manager",
+        action="store_true",
+        default=None,
+        help="Enable AWS Secrets Manager fallback when secrets are missing",
+    )
+    parser.add_argument(
+        "--no-aws-secrets-manager",
+        dest="use_aws_secrets_manager",
+        action="store_false",
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments into a namespace."""
+
+    parser = _create_parser()
+    return parser.parse_args(argv)
+
+
+def run(argv: Optional[Iterable[str]] = None) -> dict:
+    """Parse arguments and build the resulting configuration dictionary."""
+
+    args = parse_args(argv)
+    return build_config(args)
+
+
+__all__ = ["parse_args", "run", "build_config"]

--- a/src/releasecopilot/config.py
+++ b/src/releasecopilot/config.py
@@ -1,0 +1,212 @@
+"""Configuration helpers for Release Copilot."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import yaml
+
+from . import aws_secrets
+
+# Keys that the configuration system understands by default. Additional keys
+# discovered in the YAML file will also be considered for environment
+# overrides.
+KNOWN_CONFIG_KEYS: set[str] = {
+    "bitbucket_base",
+    "bitbucket_token",
+    "fix_version",
+    "jira_base",
+    "jira_token",
+    "jira_user",
+    "use_aws_secrets_manager",
+}
+
+# Keys that should be interpreted as booleans when sourced from the
+# environment.
+BOOLEAN_KEYS = {"use_aws_secrets_manager"}
+
+# Common prefixes that may be used for environment variables. The empty string
+# allows direct lookups (e.g. ``JIRA_TOKEN``) while the others support names
+# like ``RELEASECOPILOT_JIRA_TOKEN``.
+ENV_PREFIXES = ("", "RELEASECOPILOT_", "RELEASE_COPILOT_")
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration validation fails."""
+
+
+def load_yaml_defaults(path: str | Path | None) -> dict:
+    """Load YAML configuration defaults from ``path``.
+
+    If the file is missing, an empty dictionary is returned.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML file. ``None`` is treated as a missing file.
+
+    Returns
+    -------
+    dict
+        Parsed YAML data or ``{}`` if the file does not exist.
+    """
+
+    if not path:
+        return {}
+
+    yaml_path = Path(path)
+    if not yaml_path.exists():
+        return {}
+
+    with yaml_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"Expected top-level mapping in configuration file '{yaml_path}',"
+            f" but received {type(data).__name__}."
+        )
+
+    return data
+
+
+def _coerce_bool(value: str) -> bool:
+    truthy = {"1", "true", "yes", "on", "y", "t"}
+    falsy = {"0", "false", "no", "off", "n", "f"}
+    lowered = value.strip().lower()
+    if lowered in truthy:
+        return True
+    if lowered in falsy:
+        return False
+    raise ConfigError(f"Unable to interpret boolean value from '{value}'.")
+
+
+def load_env_overrides(keys: Iterable[str]) -> dict:
+    """Return environment overrides for ``keys``.
+
+    Environment lookups are case insensitive and support optional
+    ``RELEASECOPILOT_`` / ``RELEASE_COPILOT_`` prefixes. Values for keys
+    registered in :data:`BOOLEAN_KEYS` are parsed into booleans.
+    """
+
+    overrides: Dict[str, Any] = {}
+    for key in keys:
+        candidates = [key, key.upper()]
+        env_value = None
+        for candidate in candidates:
+            for prefix in ENV_PREFIXES:
+                env_key = f"{prefix}{candidate.upper()}"
+                if env_key in os.environ:
+                    env_value = os.environ[env_key]
+                    break
+            if env_value is not None:
+                break
+        if env_value is None:
+            continue
+
+        if key in BOOLEAN_KEYS:
+            overrides[key] = _coerce_bool(env_value)
+        else:
+            overrides[key] = env_value
+
+    return overrides
+
+
+def merge_configs(*dicts: Dict[str, Any]) -> dict:
+    """Merge dictionaries honoring precedence from left to right."""
+
+    merged: Dict[str, Any] = {}
+    for cfg in reversed(dicts):
+        if not cfg:
+            continue
+        merged.update(cfg)
+    return merged
+
+
+def resolve_secret(name: str, cfg: Dict[str, Any]) -> str | None:
+    """Resolve ``name`` within ``cfg`` respecting secret precedence."""
+
+    if not name:
+        raise ValueError("Secret name must be provided.")
+    if cfg is None:
+        raise ValueError("Configuration dictionary is required.")
+
+    for candidate in (name, name.lower(), name.upper()):
+        value = cfg.get(candidate)
+        if value:
+            return value
+
+    secrets = cfg.get("secrets")
+    if isinstance(secrets, dict):
+        for candidate in (name, name.lower(), name.upper()):
+            value = secrets.get(candidate)
+            if value:
+                cfg[name] = value
+                return value
+
+    if cfg.get("use_aws_secrets_manager"):
+        secret = aws_secrets.get_secret(name)
+        if secret:
+            cfg[name] = secret
+            return secret
+
+    return None
+
+
+def _extract_cli_overrides(cli_args: argparse.Namespace) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    for key, value in vars(cli_args).items():
+        if key == "config":
+            continue
+        if value is None:
+            continue
+        data[key] = value
+    return data
+
+
+def build_config(cli_args: argparse.Namespace) -> dict:
+    """Build the final configuration dictionary from CLI, env, and YAML."""
+
+    if not isinstance(cli_args, argparse.Namespace):
+        raise TypeError("cli_args must be an argparse.Namespace instance")
+
+    config_path: Path | None = None
+    if getattr(cli_args, "config", None):
+        config_path = Path(cli_args.config)
+        if not config_path.exists():
+            raise ConfigError(f"Configuration file '{config_path}' was not found.")
+    else:
+        default_path = Path("releasecopilot.yaml")
+        if default_path.exists():
+            config_path = default_path
+
+    yaml_defaults = load_yaml_defaults(config_path)
+
+    env_keys = set(KNOWN_CONFIG_KEYS)
+    env_keys.update(key for key in yaml_defaults.keys() if isinstance(key, str))
+    secrets_block = yaml_defaults.get("secrets")
+    if isinstance(secrets_block, dict):
+        env_keys.update(key for key in secrets_block.keys() if isinstance(key, str))
+
+    env_overrides = load_env_overrides(env_keys)
+    cli_overrides = _extract_cli_overrides(cli_args)
+
+    merged = merge_configs(cli_overrides, env_overrides, yaml_defaults)
+    if config_path:
+        merged["config_path"] = str(config_path)
+
+    merged["use_aws_secrets_manager"] = bool(merged.get("use_aws_secrets_manager"))
+
+    for secret_name in ("jira_token", "bitbucket_token"):
+        resolve_secret(secret_name, merged)
+
+    required_fields = ("fix_version", "jira_base", "bitbucket_base")
+    missing = [field for field in required_fields if not merged.get(field)]
+    if missing:
+        raise ConfigError(
+            "Missing required configuration values: " + ", ".join(sorted(missing))
+        )
+
+    return merged

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from releasecopilot.config import build_config, merge_configs
+
+
+def test_merge_configs_precedence():
+    low = {"key": "low", "other": "base"}
+    mid = {"key": "mid"}
+    high = {"key": "high"}
+    merged = merge_configs(high, mid, low)
+    assert merged["key"] == "high"
+    assert merged["other"] == "base"
+
+
+def test_build_config_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_path = tmp_path / "releasecopilot.yaml"
+    yaml_path.write_text(
+        """
+fix_version: 1.0.0
+jira_base: https://yaml-jira
+bitbucket_base: https://yaml-bitbucket
+"""
+    )
+
+    monkeypatch.setenv("JIRA_BASE", "https://env-jira")
+    monkeypatch.setenv("FIX_VERSION", "2.0.0")
+
+    args = argparse.Namespace(
+        config=str(yaml_path),
+        fix_version="3.0.0",
+        jira_base="https://cli-jira",
+        bitbucket_base=None,
+        jira_user=None,
+        jira_token=None,
+        bitbucket_token=None,
+        use_aws_secrets_manager=None,
+    )
+
+    config = build_config(args)
+
+    assert config["jira_base"] == "https://cli-jira"
+    assert config["fix_version"] == "3.0.0"
+    assert config["bitbucket_base"] == "https://yaml-bitbucket"
+
+
+def test_build_config_env_over_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_path = tmp_path / "releasecopilot.yaml"
+    yaml_path.write_text(
+        """
+fix_version: 1.0.0
+jira_base: https://yaml-jira
+bitbucket_base: https://yaml-bitbucket
+"""
+    )
+
+    monkeypatch.setenv("BITBUCKET_BASE", "https://env-bitbucket")
+    monkeypatch.setenv("FIX_VERSION", "2.0.0")
+
+    args = argparse.Namespace(
+        config=str(yaml_path),
+        fix_version=None,
+        jira_base=None,
+        bitbucket_base=None,
+        jira_user=None,
+        jira_token=None,
+        bitbucket_token=None,
+        use_aws_secrets_manager=None,
+    )
+
+    config = build_config(args)
+
+    assert config["bitbucket_base"] == "https://env-bitbucket"
+    assert config["fix_version"] == "2.0.0"
+    assert config["jira_base"] == "https://yaml-jira"

--- a/tests/test_secret_resolution.py
+++ b/tests/test_secret_resolution.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from releasecopilot import aws_secrets
+from releasecopilot.config import resolve_secret
+
+
+def test_resolve_secret_prefers_existing():
+    cfg = {"jira_token": "from-cli", "use_aws_secrets_manager": False}
+    assert resolve_secret("jira_token", cfg) == "from-cli"
+
+
+def test_resolve_secret_falls_back_to_yaml():
+    cfg = {
+        "use_aws_secrets_manager": False,
+        "secrets": {"jira_token": "from-yaml"},
+    }
+    assert resolve_secret("jira_token", cfg) == "from-yaml"
+    assert cfg["jira_token"] == "from-yaml"
+
+
+def test_resolve_secret_uses_aws(monkeypatch: pytest.MonkeyPatch):
+    calls: list[str] = []
+
+    def fake_get_secret(name: str) -> str:
+        calls.append(name)
+        return "from-aws"
+
+    monkeypatch.setattr(aws_secrets, "get_secret", fake_get_secret)
+
+    cfg: dict[str, object] = {"use_aws_secrets_manager": True}
+    assert resolve_secret("jira_token", cfg) == "from-aws"
+    assert resolve_secret("jira_token", cfg) == "from-aws"
+    assert calls == ["jira_token"]


### PR DESCRIPTION
## Summary
- add a configuration helper that merges YAML defaults, environment overrides, and CLI arguments while validating required fields
- wire a Release Copilot CLI parser to produce the merged config and add an AWS Secrets Manager helper with caching
- document configuration precedence and secrets handling, and add targeted pytest coverage for merging and secret resolution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc788f9fac832fb5a6690446cbcf6b