### PR TITLE
feat(ui): add streamlit audit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,39 @@ python main.py \
 | `--s3-prefix` | Prefix within the S3 bucket for uploaded artifacts. |
 | `--output-prefix` | Basename for generated output files. |
 
+## Streamlit Dashboard
+
+Explore generated audit reports with the bundled Streamlit UI. The app can open
+local JSON outputs or browse reports hosted in Amazon S3.
+
+### Running the app
+
+```bash
+streamlit run ui/app.py
+```
+
+### Local reports
+
+1. Point the "Reports folder" sidebar field to a directory containing the
+   exported `*.json` and (optionally) `*.xlsx` files. The most recent JSON file
+   is loaded automatically.
+2. A sample fixture is provided at `reports/sample.json` for quick exploration.
+
+### Amazon S3 mode
+
+1. Ensure AWS credentials are available to the process (`AWS_ACCESS_KEY_ID`,
+   `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` or a configured profile).
+2. Enter the bucket name and optional prefix. The dashboard lists runs grouped
+   by fix version and execution date. Selecting a run downloads the JSON report
+   and offers a presigned link to the Excel workbook when available.
+
+The main view surfaces KPI metrics, filters (fix version, status, assignee,
+labels/components, repository, branch, and commit date range), and tables for
+stories with commits, stories without commits, and orphan commits. Filtered
+tables can be exported as CSV files. A comparison mode allows diffing the
+current run against a previous report and integrates with the `#24` diff API via
+an optional endpoint field.
+
 ## AWS Deployment
 
 ### Lambda

--- a/reports/sample.json
+++ b/reports/sample.json
@@ -1,0 +1,87 @@
+{
+  "metadata": {
+    "fix_version": "MOB-1.0.0",
+    "generated_at": "2024-02-12T20:00:00Z"
+  },
+  "summary": {
+    "total_stories": 3,
+    "stories_with_commits": 2,
+    "stories_without_commits": 1,
+    "orphan_commits": 1
+  },
+  "commit_story_mapping": [
+    {
+      "story_key": "APP-1",
+      "story_summary": "Implement login flow",
+      "story_status": "In Progress",
+      "story_assignee": "Alice Smith",
+      "components": ["Mobile"],
+      "labels": ["frontend", "login"],
+      "fix_versions": ["MOB-1.0.0"],
+      "commits": [
+        {
+          "hash": "abc123",
+          "message": "APP-1 build login screen",
+          "author": "Alice",
+          "date": "2024-02-10T12:00:00Z",
+          "repository": "mobile-app",
+          "branch": "main"
+        }
+      ]
+    },
+    {
+      "story_key": "APP-3",
+      "story_summary": "Add analytics instrumentation",
+      "story_status": "Done",
+      "story_assignee": "Cara Jones",
+      "components": ["Tracking"],
+      "labels": ["analytics"],
+      "fix_versions": ["MOB-1.0.0", "MOB-1.1.0"],
+      "commits": [
+        {
+          "hash": "def456",
+          "message": "APP-3 add trackers",
+          "author": "Cara",
+          "date": "2024-02-11T09:15:00Z",
+          "repository": "mobile-app",
+          "branch": "release/1.0"
+        },
+        {
+          "hash": "ghi789",
+          "message": "APP-3 tests",
+          "author": "Cara",
+          "date": "2024-02-12T18:30:00Z",
+          "repository": "mobile-app",
+          "branch": "release/1.0"
+        }
+      ]
+    }
+  ],
+  "stories_with_no_commits": [
+    {
+      "key": "APP-2",
+      "fields": {
+        "summary": "Polish settings page",
+        "status": {"name": "To Do"},
+        "assignee": {"displayName": "Bob Lee"},
+        "components": [
+          {"name": "UI"}
+        ],
+        "labels": ["ux"],
+        "fixVersions": [
+          {"name": "MOB-1.0.0"}
+        ]
+      }
+    }
+  ],
+  "orphan_commits": [
+    {
+      "hash": "xyz999",
+      "message": "refactor shared utils",
+      "author": "Dana",
+      "date": "2024-02-09T08:00:00Z",
+      "repository": "shared-lib",
+      "branch": "develop"
+    }
+  ]
+}

--- a/tests/unit/ui/test_transform.py
+++ b/tests/unit/ui/test_transform.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from ui import transform
+
+
+def _load_sample_report() -> dict:
+    path = Path(__file__).resolve().parents[3] / "reports" / "sample.json"
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_compute_kpis_uses_summary_when_available() -> None:
+    report = _load_sample_report()
+    metrics = transform.compute_kpis(report)
+
+    assert metrics["total_stories"] == 3
+    assert metrics["stories_with_commits"] == 2
+    assert metrics["stories_without_commits"] == 1
+    assert metrics["orphan_commits"] == 1
+    assert metrics["coverage_percent"] == 66.67
+
+
+def test_filters_by_fix_version_and_repository() -> None:
+    report = _load_sample_report()
+    with_df, without_df = transform.prepare_story_tables(report)
+
+    filters = {"fix_versions": ["MOB-1.1.0"]}
+    filtered_with, filtered_without = transform.filter_story_tables(with_df, without_df, filters)
+
+    assert filtered_with["story_key"].tolist() == ["APP-3"]
+    assert filtered_without.empty
+
+    filters = {"repositories": ["mobile-app"], "branches": ["release/1.0"]}
+    filtered_with, _ = transform.filter_story_tables(with_df, without_df, filters)
+    assert filtered_with["story_key"].tolist() == ["APP-3"]
+
+
+def test_orphan_filters_by_date_range() -> None:
+    report = _load_sample_report()
+    orphan_df = transform.build_orphan_dataframe(report)
+    filters = {
+        "repositories": ["shared-lib"],
+        "date_range": (
+            pd.Timestamp("2024-02-09T00:00:00Z"),
+            pd.Timestamp("2024-02-09T23:59:59Z"),
+        ),
+    }
+
+    filtered = transform.filter_orphan_commits(orphan_df, filters)
+    assert filtered["hash"].tolist() == ["xyz999"]
+
+
+def test_filter_options_surface_unique_values() -> None:
+    report = _load_sample_report()
+    with_df, without_df = transform.prepare_story_tables(report)
+    orphan_df = transform.build_orphan_dataframe(report)
+
+    options = transform.get_filter_options(with_df, without_df, orphan_df)
+
+    assert "MOB-1.0.0" in options["fix_versions"]
+    assert "Done" in options["statuses"]
+    assert "Alice Smith" in options["assignees"]
+    assert "Tracking" in options["components_labels"]
+    assert "mobile-app" in options["repositories"]
+    assert options["date_range"][0] == pd.Timestamp("2024-02-09T08:00:00Z")

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,81 +1,316 @@
-"""Streamlit UI skeleton for triggering release audits."""
+"""Streamlit dashboard for browsing audit outputs."""
 from __future__ import annotations
 
 import json
-import subprocess
-from datetime import date
 from pathlib import Path
-from typing import List
+from typing import Dict, Optional
 
+import boto3
+import pandas as pd
+import requests
 import streamlit as st
 
-st.set_page_config(page_title="releasecopilot-ai", layout="wide")
+from ui.data_source import RunRef, load_local_reports, load_s3_json, load_s3_listing
+from ui import transform
 
-st.title("ReleaseCopilot-AI")
+st.set_page_config(page_title="ReleaseCopilot Audit Dashboard", layout="wide")
+
+
+@st.cache_data(show_spinner=False)
+def _cached_local(path_str: str) -> Dict[str, object]:
+    return load_local_reports(path_str)
+
+
+@st.cache_data(show_spinner=False)
+def _cached_s3_listing(bucket: str, prefix: str) -> list[RunRef]:
+    return load_s3_listing(bucket, prefix)
+
+
+@st.cache_data(show_spinner=False)
+def _cached_s3_json(bucket: str, key: str) -> Dict[str, object]:
+    return load_s3_json(bucket, key)
+
+
+@st.cache_data(show_spinner=False)
+def _cached_excel_link(bucket: str, key: str) -> Optional[str]:
+    client = boto3.client("s3")
+    try:
+        return client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=900,
+        )
+    except Exception:  # pragma: no cover - network interaction
+        return None
+
+
+st.title("ReleaseCopilot Audit Browser")
+
+st.markdown(
+    "<style>.metric-container>div{background:var(--background-color-secondary);padding:0.75rem;border-radius:0.5rem}</style>",
+    unsafe_allow_html=True,
+)
+
+selected_report: Optional[Dict[str, object]] = None
+current_json_path: Optional[Path] = None
+current_excel_path: Optional[Path] = None
+current_run_ref: Optional[RunRef] = None
+current_bucket: Optional[str] = None
+
+previous_report: Optional[Dict[str, object]] = None
+previous_label: Optional[str] = None
+previous_excel_link: Optional[str] = None
 
 with st.sidebar:
-    st.header("Audit Parameters")
-    fix_version = st.text_input("Fix Version", "MOB-1.0.0")
-    repos_raw = st.text_input("Repositories (comma separated)", "")
-    branches_raw = st.text_input("Branches (comma separated)", "")
-    freeze_date = st.date_input("Freeze Date", value=date.today())
-    develop_only = st.toggle("Develop branch only", value=False)
-    use_cache = st.toggle("Use cached payloads", value=True)
-    upload_s3 = st.toggle("Upload to S3", value=False)
-    run_btn = st.button("Run Audit")
+    st.header("Data source")
+    source = st.radio("Select source", ("Local", "Amazon S3"), index=0)
 
-output_dir = Path("artifacts")
-output_dir.mkdir(exist_ok=True)
+    if source == "Local":
+        reports_dir = st.text_input("Reports folder", "reports")
+        if reports_dir:
+            try:
+                payload = _cached_local(reports_dir)
+                selected_report = payload.get("data")  # type: ignore[assignment]
+                current_json_path = payload.get("json_path")  # type: ignore[assignment]
+                current_excel_path = payload.get("excel_path")  # type: ignore[assignment]
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+    else:
+        bucket = st.text_input("S3 bucket", key="bucket")
+        prefix = st.text_input("Prefix", key="prefix", help="Optional folder within the bucket")
+        run_options: list[RunRef] = []
+        if bucket:
+            try:
+                run_options = _cached_s3_listing(bucket, prefix)
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+        if run_options:
+            option_labels = {run.label(): run for run in run_options}
+            selection = st.selectbox("Available runs", list(option_labels.keys()))
+            if selection:
+                current_run_ref = option_labels[selection]
+                current_bucket = bucket
+                try:
+                    selected_report = _cached_s3_json(bucket, current_run_ref.json_key)
+                except Exception as exc:  # pragma: no cover - UI feedback
+                    st.error(str(exc))
+        else:
+            if bucket:
+                st.info("No JSON reports found for the provided prefix.")
 
-if run_btn:
-    cmd: List[str] = [
-        "python",
-        "-m",
-        "src.cli.main",
-        "--fix-version",
-        fix_version,
-        "--output",
-        str(output_dir),
-    ]
-    if repos_raw.strip():
-        cmd.append("--repos")
-        cmd.extend([repo.strip() for repo in repos_raw.split(",") if repo.strip()])
-    if branches_raw.strip():
-        cmd.append("--branches")
-        cmd.extend([branch.strip() for branch in branches_raw.split(",") if branch.strip()])
-    if develop_only:
-        cmd.append("--develop-only")
-    if use_cache:
-        cmd.append("--use-cache")
-    if upload_s3:
-        cmd.append("--upload-s3")
-    if freeze_date:
-        cmd.extend(["--freeze-date", freeze_date.isoformat()])
+    compare_enabled = False
+    diff_api_url = ""
+    if selected_report:
+        st.markdown("---")
+        compare_enabled = st.toggle("Compare to previous run")
+        if compare_enabled:
+            diff_api_url = st.text_input("Diff API endpoint", help="POST endpoint for the #24 diff API")
+            if source == "Local":
+                uploaded = st.file_uploader("Upload previous JSON", type="json")
+                if uploaded:
+                    previous_bytes = uploaded.getvalue()
+                    if previous_bytes:
+                        previous_report = json.loads(previous_bytes.decode("utf-8"))
+                    previous_label = uploaded.name
+            else:
+                if current_run_ref and current_bucket:
+                    candidates = [run for run in run_options if run.json_key != current_run_ref.json_key]
+                    if candidates:
+                        labels = {run.label(): run for run in candidates}
+                        previous_choice = st.selectbox("Previous run", list(labels.keys()))
+                        if previous_choice:
+                            prev_ref = labels[previous_choice]
+                            previous_label = previous_choice
+                            try:
+                                previous_report = _cached_s3_json(current_bucket, prev_ref.json_key)
+                                if prev_ref.excel_key:
+                                    previous_excel_link = _cached_excel_link(current_bucket, prev_ref.excel_key)
+                            except Exception as exc:  # pragma: no cover - UI feedback
+                                st.error(str(exc))
+                    else:
+                        st.info("No other runs available for comparison.")
 
-    st.write("Running command:")
-    st.code(" ".join(cmd))
+if not selected_report:
+    st.info("Select a reports directory or S3 run from the sidebar to begin.")
+    st.stop()
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.stdout:
-        st.subheader("CLI Output")
-        st.code(result.stdout)
-    if result.stderr:
-        st.subheader("CLI Errors")
-        st.code(result.stderr)
-    if result.returncode != 0:
-        st.error("Audit failed; check the logs above for details.")
+stories_with_df, stories_without_df = transform.prepare_story_tables(selected_report)
+orphan_df = transform.build_orphan_dataframe(selected_report)
+filter_options = transform.get_filter_options(stories_with_df, stories_without_df, orphan_df)
 
-summary_path = output_dir / "summary.json"
-if summary_path.exists():
-    st.subheader("Audit Summary")
-    st.json(json.loads(summary_path.read_text(encoding="utf-8")))
+filters: Dict[str, object] = {}
 
-for filename in ("audit_results.xlsx", "audit_results.json"):
-    file_path = output_dir / filename
-    if file_path.exists():
-        with file_path.open("rb") as fh:
+with st.sidebar:
+    st.header("Filters")
+    selected_fix_versions = st.multiselect("Fix versions", filter_options["fix_versions"])
+    if selected_fix_versions:
+        filters["fix_versions"] = selected_fix_versions
+
+    selected_statuses = st.multiselect("Jira status", filter_options["statuses"])
+    if selected_statuses:
+        filters["statuses"] = selected_statuses
+
+    selected_assignees = st.multiselect("Assignee", filter_options["assignees"])
+    if selected_assignees:
+        filters["assignees"] = selected_assignees
+
+    selected_labels = st.multiselect("Component / Label", filter_options["components_labels"])
+    if selected_labels:
+        filters["components_labels"] = selected_labels
+
+    selected_repos = st.multiselect("Repository", filter_options["repositories"])
+    if selected_repos:
+        filters["repositories"] = selected_repos
+
+    selected_branches = st.multiselect("Branch", filter_options["branches"])
+    if selected_branches:
+        filters["branches"] = selected_branches
+
+    if filter_options["date_range"]:
+        min_date, max_date = filter_options["date_range"]
+        default_start = min_date.date()
+        default_end = max_date.date()
+        chosen_dates = st.date_input(
+            "Commit date range",
+            (default_start, default_end),
+            min_value=default_start,
+            max_value=default_end,
+        )
+        if isinstance(chosen_dates, tuple) and len(chosen_dates) == 2:
+            start_dt = pd.Timestamp(chosen_dates[0])
+            end_dt = pd.Timestamp(chosen_dates[1]) + pd.Timedelta(days=1) - pd.Timedelta(microseconds=1)
+            filters["date_range"] = (start_dt, end_dt)
+
+filtered_with_df, filtered_without_df = transform.filter_story_tables(
+    stories_with_df, stories_without_df, filters
+)
+filtered_orphan_df = transform.filter_orphan_commits(orphan_df, filters)
+
+filtered_total = len(filtered_with_df) + len(filtered_without_df)
+coverage = round((len(filtered_with_df) / filtered_total * 100) if filtered_total else 0.0, 2)
+
+metric_cols = st.columns(5, gap="small")
+metric_cols[0].metric("Total stories", filtered_total)
+metric_cols[1].metric("With commits", len(filtered_with_df))
+metric_cols[2].metric("Without commits", len(filtered_without_df))
+metric_cols[3].metric("Orphan commits", len(filtered_orphan_df))
+metric_cols[4].metric("Coverage %", f"{coverage:.2f}")
+
+source_details = []
+if current_json_path:
+    source_details.append(f"Loaded from `{current_json_path}`")
+if current_run_ref and current_bucket:
+    source_details.append(
+        f"Loaded `{current_run_ref.json_key}` from `s3://{current_bucket}/{current_run_ref.json_key}`"
+    )
+if source_details:
+    st.caption("\n".join(source_details))
+
+stories_tab, missing_tab, orphan_tab, compare_tab = st.tabs(
+    ["Stories with commits", "Stories without commits", "Orphan commits", "Compare"]
+)
+
+with stories_tab:
+    st.dataframe(filtered_with_df, use_container_width=True)
+    st.download_button(
+        "Download CSV",
+        filtered_with_df.to_csv(index=False).encode("utf-8"),
+        file_name="stories_with_commits.csv",
+        mime="text/csv",
+    )
+
+with missing_tab:
+    st.dataframe(filtered_without_df, use_container_width=True)
+    st.download_button(
+        "Download CSV",
+        filtered_without_df.to_csv(index=False).encode("utf-8"),
+        file_name="stories_without_commits.csv",
+        mime="text/csv",
+    )
+
+with orphan_tab:
+    st.dataframe(filtered_orphan_df, use_container_width=True)
+    st.download_button(
+        "Download CSV",
+        filtered_orphan_df.to_csv(index=False).encode("utf-8"),
+        file_name="orphan_commits.csv",
+        mime="text/csv",
+    )
+
+    if current_excel_path:
+        with current_excel_path.open("rb") as excel_fh:
             st.download_button(
-                label=f"Download {filename}",
-                data=fh,
-                file_name=filename,
+                "Download Excel report",
+                data=excel_fh.read(),
+                file_name=current_excel_path.name,
             )
+    elif current_run_ref and current_run_ref.excel_key and current_bucket:
+        excel_link = _cached_excel_link(current_bucket, current_run_ref.excel_key)
+        if excel_link:
+            st.markdown(f"[Download Excel report]({excel_link})")
+        else:
+            st.caption(
+                f"Excel: s3://{current_bucket}/{current_run_ref.excel_key} (unable to generate presigned URL)"
+            )
+
+with compare_tab:
+    if not compare_enabled:
+        st.info("Enable comparison from the sidebar to diff against another run.")
+    elif not previous_report:
+        st.warning("Select or upload a previous run to compare.")
+    else:
+        current_metrics = transform.compute_kpis(selected_report)
+        previous_metrics = transform.compute_kpis(previous_report)
+        diff_cols = st.columns(5, gap="small")
+        diff_cols[0].metric(
+            "Total stories",
+            current_metrics["total_stories"],
+            current_metrics["total_stories"] - previous_metrics["total_stories"],
+        )
+        diff_cols[1].metric(
+            "With commits",
+            current_metrics["stories_with_commits"],
+            current_metrics["stories_with_commits"] - previous_metrics["stories_with_commits"],
+        )
+        diff_cols[2].metric(
+            "Without commits",
+            current_metrics["stories_without_commits"],
+            current_metrics["stories_without_commits"] - previous_metrics["stories_without_commits"],
+        )
+        diff_cols[3].metric(
+            "Orphan commits",
+            current_metrics["orphan_commits"],
+            current_metrics["orphan_commits"] - previous_metrics["orphan_commits"],
+        )
+        diff_cols[4].metric(
+            "Coverage %",
+            f"{current_metrics['coverage_percent']:.2f}",
+            round(current_metrics["coverage_percent"] - previous_metrics["coverage_percent"], 2),
+        )
+
+        st.markdown("### Diff API")
+        if diff_api_url:
+            if st.button("Call diff API"):
+                try:
+                    response = requests.post(
+                        diff_api_url,
+                        json={
+                            "current": selected_report,
+                            "previous": previous_report,
+                        },
+                        timeout=30,
+                    )
+                    response.raise_for_status()
+                    try:
+                        st.json(response.json())
+                    except ValueError:
+                        st.text(response.text)
+                except requests.RequestException as exc:  # pragma: no cover - network interaction
+                    st.error(f"Diff API request failed: {exc}")
+        else:
+            st.caption("Provide a diff API endpoint in the sidebar to trigger comparisons.")
+
+        if previous_label:
+            st.caption(f"Comparing against: {previous_label}")
+        if previous_excel_link:
+            st.markdown(f"[Download previous Excel report]({previous_excel_link})")

--- a/ui/data_source.py
+++ b/ui/data_source.py
@@ -1,0 +1,120 @@
+"""Data source helpers for the Streamlit dashboard."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+@dataclass(frozen=True)
+class RunRef:
+    """Reference to an audit run stored remotely."""
+
+    fix_version: str
+    run_date: str
+    json_key: str
+    excel_key: Optional[str] = None
+
+    def label(self) -> str:
+        parts = [part for part in (self.fix_version, self.run_date) if part]
+        return " / ".join(parts) if parts else self.json_key
+
+
+def load_local_reports(path: str | Path) -> Dict[str, Optional[Path] | Dict]:
+    """Load the latest report JSON (and discover Excel) from a directory."""
+
+    directory = Path(path).expanduser().resolve()
+    if not directory.exists() or not directory.is_dir():
+        raise FileNotFoundError(f"Reports directory not found: {directory}")
+
+    json_candidates = sorted(
+        directory.glob("*.json"),
+        key=lambda file: file.stat().st_mtime,
+        reverse=True,
+    )
+    if not json_candidates:
+        raise FileNotFoundError(f"No JSON files found in {directory}")
+
+    json_path = json_candidates[0]
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+
+    excel_candidates = sorted(
+        directory.glob("*.xlsx"),
+        key=lambda file: file.stat().st_mtime,
+        reverse=True,
+    )
+    excel_path = excel_candidates[0] if excel_candidates else None
+
+    return {
+        "data": data,
+        "json_path": json_path,
+        "excel_path": excel_path,
+    }
+
+
+def load_s3_listing(bucket: str, prefix: str = "") -> List[RunRef]:
+    """List available runs in S3 grouped by fix-version and date."""
+
+    client = boto3.client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+
+    cleaned_prefix = prefix.strip("/")
+    normalized_prefix = f"{cleaned_prefix}/" if cleaned_prefix else ""
+
+    runs: Dict[tuple[str, str], Dict[str, Optional[str]]] = {}
+
+    try:
+        for page in paginator.paginate(Bucket=bucket, Prefix=normalized_prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+                relative = key[len(normalized_prefix) :] if normalized_prefix else key
+                segments = [segment for segment in relative.split("/") if segment]
+                if len(segments) < 1:
+                    continue
+                if len(segments) == 1:
+                    fix_version = ""
+                    run_date = segments[0]
+                else:
+                    fix_version = segments[0]
+                    run_date = segments[1]
+                run_key = (fix_version, run_date)
+                entry = runs.setdefault(run_key, {"json": None, "excel": None})
+                if key.lower().endswith(".json"):
+                    entry["json"] = key
+                elif key.lower().endswith((".xlsx", ".xlsm")):
+                    entry["excel"] = key
+    except (ClientError, BotoCoreError) as exc:  # pragma: no cover - passthrough
+        raise RuntimeError(f"Unable to list objects in s3://{bucket}/{prefix}: {exc}") from exc
+
+    run_refs = [
+        RunRef(
+            fix_version=fix_version,
+            run_date=run_date,
+            json_key=paths["json"],
+            excel_key=paths.get("excel"),
+        )
+        for (fix_version, run_date), paths in runs.items()
+        if paths.get("json")
+    ]
+
+    run_refs.sort(key=lambda ref: (ref.fix_version, ref.run_date), reverse=True)
+    return run_refs
+
+
+def load_s3_json(bucket: str, key: str) -> Dict:
+    """Download and parse a JSON report from S3."""
+
+    client = boto3.client("s3")
+    try:
+        response = client.get_object(Bucket=bucket, Key=key)
+    except (ClientError, BotoCoreError) as exc:  # pragma: no cover - passthrough
+        raise RuntimeError(f"Unable to download s3://{bucket}/{key}: {exc}") from exc
+
+    body = response["Body"].read()
+    return json.loads(body.decode("utf-8"))

--- a/ui/transform.py
+++ b/ui/transform.py
@@ -1,0 +1,391 @@
+"""Transform helpers for the Streamlit dashboard."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+import pandas as pd
+
+StoryFilters = Dict[str, Any]
+
+
+def compute_kpis(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute KPI metrics for the dashboard."""
+
+    summary = report.get("summary", {})
+    total_stories = summary.get("total_stories")
+    stories_with_commits = summary.get("stories_with_commits")
+    stories_without_commits = summary.get("stories_without_commits")
+
+    if total_stories is None:
+        with_commits = len(report.get("commit_story_mapping", []))
+        without_commits = len(report.get("stories_with_no_commits", []))
+        total_stories = with_commits + without_commits
+        stories_with_commits = stories_with_commits or with_commits
+        stories_without_commits = stories_without_commits or without_commits
+
+    orphan_commits = summary.get("orphan_commits")
+    if orphan_commits is None:
+        orphan_commits = len(report.get("orphan_commits", []))
+
+    coverage = 0.0
+    if total_stories:
+        coverage = (stories_with_commits or 0) / total_stories * 100
+
+    return {
+        "total_stories": total_stories,
+        "stories_with_commits": stories_with_commits or 0,
+        "stories_without_commits": stories_without_commits or 0,
+        "orphan_commits": orphan_commits,
+        "coverage_percent": round(coverage, 2),
+    }
+
+
+def prepare_story_tables(report: Dict[str, Any]) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Return dataframes for stories with and without commits."""
+
+    with_rows: List[Dict[str, Any]] = []
+    for entry in report.get("commit_story_mapping", []):
+        commits = entry.get("commits", [])
+        dates = [pd.to_datetime(commit.get("date")) for commit in commits if commit.get("date")]
+        with_rows.append(
+            {
+                "story_key": entry.get("story_key"),
+                "summary": _first_of(
+                    entry.get("story_summary"),
+                    entry.get("summary"),
+                    entry.get("fields", {}).get("summary"),
+                ),
+                "status": _extract_status(entry),
+                "assignee": _extract_assignee(entry),
+                "fix_versions": _extract_names(entry, "fix_versions"),
+                "components": _extract_names(entry, "components"),
+                "labels": _ensure_list(entry.get("labels")),
+                "all_labels": _collect_labels(entry),
+                "repositories": sorted(
+                    {
+                        commit.get("repository")
+                        for commit in commits
+                        if commit.get("repository")
+                    }
+                ),
+                "branches": sorted(
+                    {
+                        commit.get("branch")
+                        for commit in commits
+                        if commit.get("branch")
+                    }
+                ),
+                "latest_commit_date": max(dates) if dates else pd.NaT,
+                "commit_count": len(commits),
+                "has_commits": True,
+            }
+        )
+
+    without_rows: List[Dict[str, Any]] = []
+    for entry in report.get("stories_with_no_commits", []):
+        fields = entry.get("fields", {})
+        without_rows.append(
+            {
+                "story_key": entry.get("key"),
+                "summary": fields.get("summary"),
+                "status": _extract_status(entry),
+                "assignee": _extract_assignee(entry),
+                "fix_versions": _extract_names(entry, "fixVersions"),
+                "components": _extract_names(entry, "components"),
+                "labels": _ensure_list(fields.get("labels")),
+                "all_labels": _collect_labels(entry),
+                "repositories": [],
+                "branches": [],
+                "latest_commit_date": pd.NaT,
+                "commit_count": 0,
+                "has_commits": False,
+            }
+        )
+
+    columns = [
+        "story_key",
+        "summary",
+        "status",
+        "assignee",
+        "fix_versions",
+        "components",
+        "labels",
+        "all_labels",
+        "repositories",
+        "branches",
+        "latest_commit_date",
+        "commit_count",
+        "has_commits",
+    ]
+    with_df = pd.DataFrame(with_rows, columns=columns)
+    without_df = pd.DataFrame(without_rows, columns=columns)
+    return with_df, without_df
+
+
+def build_orphan_dataframe(report: Dict[str, Any]) -> pd.DataFrame:
+    """Return dataframe for orphan commits."""
+
+    rows = []
+    for commit in report.get("orphan_commits", []):
+        rows.append(
+            {
+                "hash": commit.get("hash"),
+                "message": commit.get("message"),
+                "author": commit.get("author"),
+                "date": pd.to_datetime(commit.get("date")) if commit.get("date") else pd.NaT,
+                "repository": commit.get("repository"),
+                "branch": commit.get("branch"),
+            }
+        )
+    return pd.DataFrame(rows, columns=["hash", "message", "author", "date", "repository", "branch"])
+
+
+def filter_story_tables(
+    stories_with_commits: pd.DataFrame,
+    stories_without_commits: pd.DataFrame,
+    filters: StoryFilters,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Apply sidebar filters to story tables."""
+
+    filtered_with = _apply_story_filters(stories_with_commits, filters)
+    filtered_without = _apply_story_filters(stories_without_commits, filters)
+    return filtered_with, filtered_without
+
+
+def filter_orphan_commits(orphan_df: pd.DataFrame, filters: StoryFilters) -> pd.DataFrame:
+    """Apply filters to the orphan commits table."""
+
+    if orphan_df.empty:
+        return orphan_df
+
+    df = orphan_df.copy()
+    repositories = filters.get("repositories")
+    if repositories:
+        df = df[df["repository"].isin(repositories)]
+
+    branches = filters.get("branches")
+    if branches:
+        df = df[df["branch"].isin(branches)]
+
+    date_range = filters.get("date_range")
+    if date_range and not df.empty:
+        start, end = date_range
+        if start:
+            df = df[df["date"].notna() & (df["date"] >= start)]
+        if end:
+            df = df[df["date"] <= end]
+
+    return df
+
+
+def get_filter_options(
+    stories_with_commits: pd.DataFrame,
+    stories_without_commits: pd.DataFrame,
+    orphan_df: pd.DataFrame,
+) -> Dict[str, Sequence[Any]]:
+    """Collect filter options from the loaded data."""
+
+    combined = pd.concat([stories_with_commits, stories_without_commits], ignore_index=True)
+
+    fix_versions = sorted(
+        {
+            item
+            for sublist in combined.get("fix_versions", pd.Series(dtype="object"))
+            if isinstance(sublist, list)
+            for item in sublist
+        }
+    )
+    statuses = sorted({value for value in combined.get("status", []) if value})
+    assignees = sorted({value for value in combined.get("assignee", []) if value})
+    labels = sorted(
+        {
+            label
+            for sublist in combined.get("all_labels", pd.Series(dtype="object"))
+            if isinstance(sublist, list)
+            for label in sublist
+        }
+    )
+    repositories = sorted(
+        {
+            repo
+            for sublist in combined.get("repositories", pd.Series(dtype="object"))
+            if isinstance(sublist, list)
+            for repo in sublist
+        }
+        | {
+            repo
+            for repo in orphan_df.get("repository", [])
+            if repo
+        }
+    )
+    branches = sorted(
+        {
+            branch
+            for sublist in combined.get("branches", pd.Series(dtype="object"))
+            if isinstance(sublist, list)
+            for branch in sublist
+        }
+        | {
+            branch
+            for branch in orphan_df.get("branch", [])
+            if branch
+        }
+    )
+
+    date_min = pd.NaT
+    date_max = pd.NaT
+    if not stories_with_commits.empty:
+        commit_dates = stories_with_commits["latest_commit_date"].dropna()
+        if not commit_dates.empty:
+            date_min = commit_dates.min()
+            date_max = commit_dates.max()
+    if not orphan_df.empty:
+        orphan_dates = orphan_df["date"].dropna()
+        if not orphan_dates.empty:
+            date_min = _min_ignore_na(date_min, orphan_dates.min())
+            date_max = _max_ignore_na(date_max, orphan_dates.max())
+
+    return {
+        "fix_versions": fix_versions,
+        "statuses": statuses,
+        "assignees": assignees,
+        "components_labels": labels,
+        "repositories": repositories,
+        "branches": branches,
+        "date_range": (date_min, date_max) if date_min is not pd.NaT and date_max is not pd.NaT else None,
+    }
+
+
+def _apply_story_filters(df: pd.DataFrame, filters: StoryFilters) -> pd.DataFrame:
+    if df.empty:
+        return df
+
+    result = df.copy()
+
+    fix_versions = filters.get("fix_versions")
+    if fix_versions:
+        result = result[result["fix_versions"].apply(lambda items: _contains_any(items, fix_versions))]
+
+    statuses = filters.get("statuses")
+    if statuses:
+        result = result[result["status"].isin(statuses)]
+
+    assignees = filters.get("assignees")
+    if assignees:
+        result = result[result["assignee"].isin(assignees)]
+
+    labels = filters.get("components_labels")
+    if labels:
+        result = result[result["all_labels"].apply(lambda items: _contains_any(items, labels))]
+
+    repositories = filters.get("repositories")
+    if repositories:
+        result = result[result["repositories"].apply(lambda items: _contains_any(items, repositories))]
+
+    branches = filters.get("branches")
+    if branches:
+        result = result[result["branches"].apply(lambda items: _contains_any(items, branches))]
+
+    date_range = filters.get("date_range")
+    if date_range:
+        start, end = date_range
+        if start is not None:
+            result = result[result["latest_commit_date"].notna() & (result["latest_commit_date"] >= start)]
+        if end is not None:
+            result = result[result["latest_commit_date"] <= end]
+
+    return result
+
+
+def _extract_status(entry: Dict[str, Any]) -> Any:
+    if "story_status" in entry:
+        return entry.get("story_status")
+    fields = entry.get("fields") or {}
+    status = fields.get("status")
+    if isinstance(status, dict):
+        return status.get("name")
+    return entry.get("status")
+
+
+def _extract_assignee(entry: Dict[str, Any]) -> Any:
+    if "story_assignee" in entry:
+        return entry.get("story_assignee")
+    fields = entry.get("fields") or {}
+    assignee = fields.get("assignee")
+    if isinstance(assignee, dict):
+        return assignee.get("displayName") or assignee.get("name")
+    return entry.get("assignee")
+
+
+def _extract_names(entry: Dict[str, Any], key: str) -> List[str]:
+    values = entry.get(key)
+    if not values and isinstance(entry.get("fields"), dict):
+        values = entry["fields"].get(key)
+    return _ensure_list(values)
+
+
+def _collect_labels(entry: Dict[str, Any]) -> List[str]:
+    labels: List[str] = []
+    for key in ("components", "labels", "fix_versions", "fixVersions"):
+        labels.extend(_ensure_list(entry.get(key)))
+        fields = entry.get("fields") or {}
+        if isinstance(fields, dict) and key in fields:
+            labels.extend(_ensure_list(fields.get(key)))
+    # deduplicate while preserving order
+    seen = set()
+    unique = []
+    for item in labels:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return unique
+
+
+def _ensure_list(value: Any) -> List[str]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        result = []
+        for item in value:
+            if isinstance(item, dict):
+                name = item.get("name")
+                if name:
+                    result.append(str(name))
+            elif item:
+                result.append(str(item))
+        return result
+    if isinstance(value, dict):
+        name = value.get("name")
+        return [str(name)] if name else []
+    return [str(value)]
+
+
+def _contains_any(items: Iterable[Any], candidates: Sequence[Any]) -> bool:
+    if isinstance(items, str):
+        iterable: Iterable[Any] = [items]
+    elif isinstance(items, Iterable):
+        iterable = items
+    else:
+        return False
+    items_set = {str(item) for item in iterable if item is not None}
+    candidates_set = {str(candidate) for candidate in candidates}
+    return bool(items_set & candidates_set)
+
+
+def _first_of(*values: Any) -> Any:
+    for value in values:
+        if value:
+            return value
+    return None
+
+
+def _min_ignore_na(current: pd.Timestamp, candidate: pd.Timestamp) -> pd.Timestamp:
+    if current is pd.NaT:
+        return candidate
+    return min(current, candidate)
+
+
+def _max_ignore_na(current: pd.Timestamp, candidate: pd.Timestamp) -> pd.Timestamp:
+    if current is pd.NaT:
+        return candidate
+    return max(current, candidate)


### PR DESCRIPTION
## Summary
- replace the placeholder Streamlit app with a dashboard that loads audit reports from local folders or S3
- add reusable data loaders, dataframe transforms, and lightweight CSS plus CSV/export/comparison actions
- provide a sample JSON fixture, README guidance, and unit tests that exercise KPI and filtering helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdcad3493c832f8047b7eca985b31b