### PR TITLE
Add audit diff utilities and Streamlit compare view

### DIFF
--- a/docs/export-schema.md
+++ b/docs/export-schema.md
@@ -1,0 +1,64 @@
+# Audit Export Schema
+
+ReleaseCopilot exporters emit a stable JSON document describing a single audit run. The
+schema below is the contract consumed by the diff tooling and the Streamlit dashboard.
+
+## Top-level shape
+
+```jsonc
+{
+  "stories": [Story, ...],
+  "commits": [Commit, ...],
+  "summary": Summary
+}
+```
+
+Unknown properties may be added over time, but the keys documented here must always be
+present.
+
+## Story objects
+
+Each `Story` element describes a single work item.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Internal identifier from the source tracker (e.g. Jira). |
+| `key` | string | Human readable issue key, used as the primary identifier. |
+| `summary` | string | Short description or title. |
+| `status` | string | Current workflow status. |
+| `assignee` | string or null | Display name of the current assignee. |
+| `components` | array of strings | Optional component or label names. |
+| `fixVersions` | array of strings | Versions associated with the story. |
+| `commitIds` | array of strings | Commit identifiers linked to the story. |
+
+Additional metadata (like URLs) can be stored alongside these fields without breaking the
+contract.
+
+## Commit objects
+
+Each `Commit` element captures a single VCS commit.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Commit SHA or identifier. |
+| `repo` | string | Repository name. |
+| `author` | string | Author display name. |
+| `date` | string | ISO-8601 timestamp. |
+| `message` | string | Commit message subject. |
+| `linkedStoryKeys` | array of strings | Story keys associated with the commit. Empty when the commit is orphaned. |
+
+## Summary block
+
+The `summary` object aggregates counters and high-level timestamps for the run.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `generatedAt` | string | ISO-8601 timestamp when the run completed. |
+| `storyCount` | integer | Total number of stories exported. |
+| `storyWithCommitsCount` | integer | Number of stories that have at least one linked commit. |
+| `storyWithoutCommitsCount` | integer | Number of stories with no linked commits. |
+| `orphanCommitCount` | integer | Number of commits without a linked story. |
+| `coveragePercent` | number | Percentage of stories with commits (`storyWithCommitsCount / storyCount * 100`). |
+
+Exporters may include additional metrics, but these fields provide a consistent baseline
+for diffing and reporting.

--- a/src/tracking/__init__.py
+++ b/src/tracking/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for comparing ReleaseCopilot audit runs."""
+from .diff import diff_runs, render_diff_markdown
+
+__all__ = ["diff_runs", "render_diff_markdown"]

--- a/src/tracking/api.py
+++ b/src/tracking/api.py
@@ -1,0 +1,29 @@
+"""Public API for comparing audit run artifacts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .diff import diff_runs
+
+
+def _load_reference(ref: Any) -> Mapping[str, Any]:
+    if isinstance(ref, Mapping):
+        return ref
+    if isinstance(ref, (str, Path)):
+        path = Path(ref)
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, Mapping):  # pragma: no cover - defensive
+            raise TypeError("Loaded JSON is not a mapping")
+        return data
+    raise TypeError("Unsupported reference type. Expected mapping or path-like object.")
+
+
+def compare(old_ref: Any, new_ref: Any) -> dict[str, Any]:
+    """Compare two references pointing to audit runs."""
+
+    old_payload = _load_reference(old_ref)
+    new_payload = _load_reference(new_ref)
+    return diff_runs(old_payload, new_payload)

--- a/src/tracking/diff.py
+++ b/src/tracking/diff.py
@@ -1,0 +1,220 @@
+"""Diff utilities for comparing audit run JSON artifacts."""
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, Sequence
+
+
+def _is_sequence(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+
+
+def _story_index(run: Mapping[str, object]) -> Dict[str, Mapping[str, object]]:
+    stories = run.get("stories")
+    if not _is_sequence(stories):
+        return {}
+    index: Dict[str, Mapping[str, object]] = {}
+    for story in stories:  # type: ignore[assignment]
+        if isinstance(story, Mapping):
+            key = story.get("key")
+            if isinstance(key, str) and key:
+                index[key] = story
+    return index
+
+
+def _story_commit_ids(story: Mapping[str, object]) -> List[str]:
+    commit_ids = story.get("commitIds")
+    if not _is_sequence(commit_ids):
+        return []
+    values: List[str] = []
+    for commit_id in commit_ids:  # type: ignore[assignment]
+        if isinstance(commit_id, str):
+            values.append(commit_id)
+    return values
+
+
+def _orphans(run: Mapping[str, object]) -> List[str]:
+    commits = run.get("commits")
+    if not _is_sequence(commits):
+        return []
+    orphan_ids: List[str] = []
+    for commit in commits:  # type: ignore[assignment]
+        if not isinstance(commit, Mapping):
+            continue
+        linked = commit.get("linkedStoryKeys")
+        if _is_sequence(linked) and len(linked) > 0:
+            continue
+        if isinstance(linked, (str, bytes, bytearray)) and linked:
+            continue
+        commit_id = commit.get("id")
+        if isinstance(commit_id, str):
+            orphan_ids.append(commit_id)
+    return sorted(orphan_ids)
+
+
+def _coverage_percent(run: Mapping[str, object]) -> float:
+    stories = list(_story_index(run).values())
+    total = len(stories)
+    if total == 0:
+        return 0.0
+    with_commits = sum(1 for story in stories if _story_commit_ids(story))
+    return round((with_commits / total) * 100, 2)
+
+
+def _diff_commit_lists(
+    old: Mapping[str, object], new: Mapping[str, object]
+) -> tuple[List[Dict[str, object]], List[Dict[str, object]]]:
+    added: List[Dict[str, object]] = []
+    removed: List[Dict[str, object]] = []
+
+    old_index = _story_index(old)
+    new_index = _story_index(new)
+    shared_keys = sorted(set(old_index) & set(new_index))
+    new_only_keys = sorted(set(new_index) - set(old_index))
+    removed_keys = sorted(set(old_index) - set(new_index))
+
+    for key in shared_keys:
+        old_commits = set(_story_commit_ids(old_index[key]))
+        new_commits = set(_story_commit_ids(new_index[key]))
+
+        added_ids = sorted(new_commits - old_commits)
+        removed_ids = sorted(old_commits - new_commits)
+
+        if added_ids:
+            added.append({"key": key, "commit_ids": added_ids})
+        if removed_ids:
+            removed.append({"key": key, "commit_ids": removed_ids})
+
+    for key in new_only_keys:
+        commit_ids = sorted(set(_story_commit_ids(new_index[key])))
+        if commit_ids:
+            added.append({"key": key, "commit_ids": commit_ids})
+
+    for key in removed_keys:
+        commit_ids = sorted(set(_story_commit_ids(old_index[key])))
+        if commit_ids:
+            removed.append({"key": key, "commit_ids": commit_ids})
+
+    added.sort(key=lambda item: item.get("key", ""))
+    removed.sort(key=lambda item: item.get("key", ""))
+
+    return added, removed
+
+
+def diff_runs(old: Mapping[str, object], new: Mapping[str, object]) -> Dict[str, object]:
+    """Generate a deterministic diff structure between two audit runs."""
+
+    old_index = _story_index(old)
+    new_index = _story_index(new)
+
+    old_keys = set(old_index)
+    new_keys = set(new_index)
+
+    stories_added = sorted(new_keys - old_keys)
+    stories_removed = sorted(old_keys - new_keys)
+
+    status_changes: List[Dict[str, object]] = []
+    assignee_changes: List[Dict[str, object]] = []
+
+    for key in sorted(old_keys & new_keys):
+        old_story = old_index[key]
+        new_story = new_index[key]
+
+        old_status = old_story.get("status") if isinstance(old_story, Mapping) else None
+        new_status = new_story.get("status") if isinstance(new_story, Mapping) else None
+        if old_status != new_status:
+            status_changes.append({"key": key, "from": old_status, "to": new_status})
+
+        old_assignee = (
+            old_story.get("assignee") if isinstance(old_story, Mapping) else None
+        )
+        new_assignee = (
+            new_story.get("assignee") if isinstance(new_story, Mapping) else None
+        )
+        if old_assignee != new_assignee:
+            assignee_changes.append({"key": key, "from": old_assignee, "to": new_assignee})
+
+    commits_added, commits_removed = _diff_commit_lists(old, new)
+
+    old_orphans = _orphans(old)
+    new_orphans = _orphans(new)
+
+    new_orphan_ids = sorted(set(new_orphans) - set(old_orphans))
+    resolved_orphan_ids = sorted(set(old_orphans) - set(new_orphans))
+
+    previous_coverage = _coverage_percent(old)
+    current_coverage = _coverage_percent(new)
+
+    return {
+        "stories_added": stories_added,
+        "stories_removed": stories_removed,
+        "status_changes": status_changes,
+        "assignee_changes": assignee_changes,
+        "commits_added": commits_added,
+        "commits_removed": commits_removed,
+        "new_orphans": new_orphan_ids,
+        "resolved_orphans": resolved_orphan_ids,
+        "coverage_previous": previous_coverage,
+        "coverage_current": current_coverage,
+        "coverage_delta": round(current_coverage - previous_coverage, 2),
+    }
+
+
+def render_diff_markdown(diff: Mapping[str, object]) -> str:
+    """Render a markdown bullet summary for a diff."""
+
+    lines: List[str] = []
+
+    stories_added = diff.get("stories_added")
+    if isinstance(stories_added, Sequence) and stories_added:
+        items = ", ".join(str(item) for item in stories_added)
+        lines.append(f"- Stories added: {items}")
+
+    stories_removed = diff.get("stories_removed")
+    if isinstance(stories_removed, Sequence) and stories_removed:
+        items = ", ".join(str(item) for item in stories_removed)
+        lines.append(f"- Stories removed: {items}")
+
+    status_changes = diff.get("status_changes")
+    if isinstance(status_changes, Sequence) and status_changes:
+        changes = ", ".join(
+            f"{item.get('key')}: {item.get('from')} → {item.get('to')}"
+            for item in status_changes
+            if isinstance(item, Mapping)
+        )
+        if changes:
+            lines.append(f"- Status changes: {changes}")
+
+    assignee_changes = diff.get("assignee_changes")
+    if isinstance(assignee_changes, Sequence) and assignee_changes:
+        changes = ", ".join(
+            f"{item.get('key')}: {item.get('from')} → {item.get('to')}"
+            for item in assignee_changes
+            if isinstance(item, Mapping)
+        )
+        if changes:
+            lines.append(f"- Assignee changes: {changes}")
+
+    new_orphans = diff.get("new_orphans")
+    if isinstance(new_orphans, Sequence) and new_orphans:
+        items = ", ".join(str(item) for item in new_orphans)
+        lines.append(f"- New orphan commits: {items}")
+
+    resolved_orphans = diff.get("resolved_orphans")
+    if isinstance(resolved_orphans, Sequence) and resolved_orphans:
+        items = ", ".join(str(item) for item in resolved_orphans)
+        lines.append(f"- Resolved orphan commits: {items}")
+
+    coverage_delta = diff.get("coverage_delta")
+    if isinstance(coverage_delta, (int, float)) and coverage_delta:
+        current = diff.get("coverage_current")
+        previous = diff.get("coverage_previous")
+        if isinstance(current, (int, float)) and isinstance(previous, (int, float)):
+            lines.append(
+                f"- Coverage changed by {coverage_delta:+.2f}% (from {previous:.2f}% to {current:.2f}%)"
+            )
+        else:
+            lines.append(f"- Coverage changed by {coverage_delta:+.2f}%")
+
+    if not lines:
+        return "No differences detected."
+    return "\n".join(lines)

--- a/src/tracking/diff_cli.py
+++ b/src/tracking/diff_cli.py
@@ -1,0 +1,45 @@
+"""Command line interface for diffing ReleaseCopilot audit runs."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .diff import diff_runs, render_diff_markdown
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--old", required=True, type=Path, help="Path to the previous JSON artifact")
+    parser.add_argument("--new", required=True, type=Path, help="Path to the new JSON artifact")
+    parser.add_argument("--out", type=Path, help="Optional path to write the markdown summary")
+    parser.add_argument("--json", dest="json_out", type=Path, help="Optional path to write the raw diff JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    old_payload = _load_json(args.old)
+    new_payload = _load_json(args.new)
+
+    diff = diff_runs(old_payload, new_payload)
+    markdown = render_diff_markdown(diff)
+
+    if args.out:
+        args.out.write_text(markdown + "\n", encoding="utf-8")
+    if args.json_out:
+        args.json_out.write_text(json.dumps(diff, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/fixtures/tracking/new_run.json
+++ b/tests/fixtures/tracking/new_run.json
@@ -1,0 +1,66 @@
+{
+  "stories": [
+    {
+      "id": "1",
+      "key": "RC-1",
+      "summary": "Initial story",
+      "status": "Done",
+      "assignee": "Bob",
+      "components": ["backend"],
+      "fixVersions": ["1.1"],
+      "commitIds": ["c1", "c2"]
+    },
+    {
+      "id": "3",
+      "key": "RC-3",
+      "summary": "New work",
+      "status": "In Progress",
+      "assignee": "Carol",
+      "components": ["frontend"],
+      "fixVersions": ["1.1"],
+      "commitIds": ["c3"]
+    }
+  ],
+  "commits": [
+    {
+      "id": "c1",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-01T00:00:00Z",
+      "message": "feat: start",
+      "linkedStoryKeys": ["RC-1"]
+    },
+    {
+      "id": "c2",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-03T00:00:00Z",
+      "message": "feat: finish",
+      "linkedStoryKeys": ["RC-1"]
+    },
+    {
+      "id": "c3",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-04T00:00:00Z",
+      "message": "feat: new",
+      "linkedStoryKeys": ["RC-3"]
+    },
+    {
+      "id": "c-orphan-new",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-05T00:00:00Z",
+      "message": "chore: orphan",
+      "linkedStoryKeys": []
+    }
+  ],
+  "summary": {
+    "generatedAt": "2024-01-05T10:00:00Z",
+    "storyCount": 2,
+    "storyWithCommitsCount": 2,
+    "storyWithoutCommitsCount": 0,
+    "orphanCommitCount": 1,
+    "coveragePercent": 100.0
+  }
+}

--- a/tests/fixtures/tracking/old_run.json
+++ b/tests/fixtures/tracking/old_run.json
@@ -1,0 +1,50 @@
+{
+  "stories": [
+    {
+      "id": "1",
+      "key": "RC-1",
+      "summary": "Initial story",
+      "status": "In Progress",
+      "assignee": "Alice",
+      "components": ["backend"],
+      "fixVersions": ["1.0"],
+      "commitIds": ["c1"]
+    },
+    {
+      "id": "2",
+      "key": "RC-2",
+      "summary": "Another story",
+      "status": "Todo",
+      "assignee": null,
+      "components": [],
+      "fixVersions": [],
+      "commitIds": []
+    }
+  ],
+  "commits": [
+    {
+      "id": "c1",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-01T00:00:00Z",
+      "message": "feat: start",
+      "linkedStoryKeys": ["RC-1"]
+    },
+    {
+      "id": "c-orphan-old",
+      "repo": "service",
+      "author": "Dev",
+      "date": "2024-01-02T00:00:00Z",
+      "message": "chore: orphan",
+      "linkedStoryKeys": []
+    }
+  ],
+  "summary": {
+    "generatedAt": "2024-01-02T10:00:00Z",
+    "storyCount": 2,
+    "storyWithCommitsCount": 1,
+    "storyWithoutCommitsCount": 1,
+    "orphanCommitCount": 1,
+    "coveragePercent": 50.0
+  }
+}

--- a/tests/unit/tracking/test_diff.py
+++ b/tests/unit/tracking/test_diff.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tracking import api as tracking_api
+from tracking.diff import diff_runs, render_diff_markdown
+
+
+@pytest.fixture()
+def sample_runs() -> tuple[dict[str, object], dict[str, object]]:
+    base = Path(__file__).parents[2] / "fixtures" / "tracking"
+    with (base / "old_run.json").open("r", encoding="utf-8") as fh:
+        old_data = json.load(fh)
+    with (base / "new_run.json").open("r", encoding="utf-8") as fh:
+        new_data = json.load(fh)
+    return old_data, new_data
+
+
+def test_diff_runs_detects_changes(sample_runs: tuple[dict[str, object], dict[str, object]]) -> None:
+    old_run, new_run = sample_runs
+    diff = diff_runs(old_run, new_run)
+
+    assert diff["stories_added"] == ["RC-3"]
+    assert diff["stories_removed"] == ["RC-2"]
+    assert diff["status_changes"] == [
+        {"key": "RC-1", "from": "In Progress", "to": "Done"},
+    ]
+    assert diff["assignee_changes"] == [
+        {"key": "RC-1", "from": "Alice", "to": "Bob"},
+    ]
+    assert diff["commits_added"] == [
+        {"key": "RC-1", "commit_ids": ["c2"]},
+        {"key": "RC-3", "commit_ids": ["c3"]},
+    ]
+    assert diff["commits_removed"] == []
+    assert diff["new_orphans"] == ["c-orphan-new"]
+    assert diff["resolved_orphans"] == ["c-orphan-old"]
+    assert diff["coverage_previous"] == 50.0
+    assert diff["coverage_current"] == 100.0
+    assert diff["coverage_delta"] == 50.0
+
+
+def test_render_diff_markdown(sample_runs: tuple[dict[str, object], dict[str, object]]) -> None:
+    old_run, new_run = sample_runs
+    diff = diff_runs(old_run, new_run)
+
+    markdown = render_diff_markdown(diff)
+    assert "Stories added: RC-3" in markdown
+    assert "Stories removed: RC-2" in markdown
+    assert "Coverage changed by +50.00%" in markdown
+
+
+def test_compare_supports_paths(tmp_path: Path, sample_runs: tuple[dict[str, object], dict[str, object]]) -> None:
+    old_run, new_run = sample_runs
+    old_path = tmp_path / "old.json"
+    new_path = tmp_path / "new.json"
+    old_path.write_text(json.dumps(old_run), encoding="utf-8")
+    new_path.write_text(json.dumps(new_run), encoding="utf-8")
+
+    diff = tracking_api.compare(old_path, new_path)
+    assert diff["stories_added"] == ["RC-3"]


### PR DESCRIPTION
## Summary
- document the stable audit export JSON schema
- add tracking diff utilities, CLI, and public API for comparing runs
- integrate compare tab with diff summary/tables and add unit fixtures for regression

## Testing
- pytest tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68cdd069e2a0832f9533bfaef742676c