### PR TITLE
Add baseline CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+      - 'feature/**'
+
+jobs:
+  python-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Ruff (errors only)
+        run: ruff check --select F,E9 .
+
+      - name: Pytest
+        run: pytest -q
+
+  package:
+    runs-on: ubuntu-latest
+    needs: python-checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Package Lambda
+        run: bash scripts/package_lambda.sh
+
+      - name: Zip Lambda bundle
+        run: |
+          cd dist/lambda
+          zip -r ../lambda_bundle.zip .
+
+      - name: Upload Lambda artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda_bundle.zip
+          path: dist/lambda_bundle.zip
+
+  cdk-synth:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'cdk/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt -r cdk/requirements.txt
+
+      - name: Package Lambda for synth
+        run: bash scripts/package_lambda.sh
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install CDK CLI
+        run: npm install -g aws-cdk@2
+
+      - name: CDK synth
+        working-directory: infra/cdk
+        run: cdk synth

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ tables can be exported as CSV files. A comparison mode allows diffing the
 current run against a previous report and integrates with the `#24` diff API via
 an optional endpoint field.
 
+## CI pipeline
+
+Every push or pull request that targets `main` or any `feature/*` branch runs the
+baseline GitHub Actions workflow defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+The pipeline provisions Python 3.11, installs both the runtime and development
+dependencies, runs focused Ruff lint checks (syntax and runtime errors) and the
+pytest suite, and invokes the existing packaging helper to build the Lambda
+bundle. A follow-up job ensures the infrastructure code synthesises by running
+`cdk synth` from `infra/cdk` with the AWS CDK CLI. When a tag matching
+`v*.*.*` is pushed, the packaged `lambda_bundle.zip` artifact is uploaded to the
+run for download.
+
 ## AWS Deployment
 
 ### Lambda

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+aws-cdk-lib==2.154.1
+constructs==10.3.0
+python-dotenv>=1.0.0
+ruff==0.5.7
+pytest==8.3.3

--- a/services/ingest/jira_ingestor/jira_api.py
+++ b/services/ingest/jira_ingestor/jira_api.py
@@ -1,4 +1,6 @@
-import time, json, requests
+import time
+
+import requests
 from tenacity import retry, wait_exponential, stop_after_attempt
 
 # --- OAuth token refresh ---
@@ -54,7 +56,6 @@ def search_page(base_url, token, jql, fields_csv, start_at=0, max_results=100):
 # --- Fetch all comments if truncated on search response ---
 def get_all_comments_if_needed(base_url, token, issue):
     f = issue.get("fields", {})
-    summary = f.get("summary")
     comment_block = f.get("comment") or {}
     comments = comment_block.get("comments", []) or []
     total = comment_block.get("total", len(comments))

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 
 def test_cli_dry_run(tmp_path):


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs linting, tests, packaging, and CDK synthesis on pushes, pull requests, and release tags
- introduce a development requirements file that installs lint, test, and CDK tooling
- document the new continuous integration pipeline in the project README and tidy lint-only fixes to satisfy the workflow

## Testing
- ruff check --select F,E9 .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1cf4cacc0832f90b0c4d0b70a8c20