### PR TITLE
Add S3 artifact uploader with AWS metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ python main.py \
   --fix-version 2025.09.20 \
   --repos policycenter claimcenter \
   --develop-only \
-  --upload-s3
+  --s3-bucket my-artifacts-bucket \
+  --s3-prefix audits
 ```
 
 ### Available Options
@@ -95,10 +96,29 @@ python main.py \
 | `--freeze-date` | ISO date representing the code freeze (default: today). |
 | `--window-days` | Days of history to analyze before the freeze date (default: 28). |
 | `--use-cache` | Reuse the latest cached API payloads instead of calling APIs. |
-| `--upload-s3` | Upload generated artifacts to S3 after completion. |
 | `--s3-bucket` | Override the S3 bucket defined in `config/settings.yaml`. |
-| `--s3-prefix` | Prefix within the S3 bucket for uploaded artifacts. |
+| `--s3-prefix` | Prefix within the S3 bucket for uploaded artifacts (default: `releasecopilot`). |
 | `--output-prefix` | Basename for generated output files. |
+
+### S3 Upload Layout
+
+When an S3 bucket is configured via CLI, configuration, or environment variables,
+the audit automatically uploads generated artifacts after a successful run. The
+files are grouped by fix version and execution timestamp using the pattern:
+
+```
+s3://<bucket>/<prefix>/<fix-version>/<YYYY-MM-DD_HHMMSS>/
+├── reports/
+│   ├── <output-prefix>.json
+│   ├── <output-prefix>.xlsx
+│   └── summary.json
+└── raw/
+    ├── jira_issues.json
+    └── bitbucket_commits.json
+```
+
+Each object is encrypted with SSE-S3 and tagged with metadata that captures the
+fix version, generation timestamp, and the current Git SHA when available.
 
 ## Streamlit Dashboard
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -3,7 +3,7 @@
 aws:
   region: us-east-1
   s3_bucket: releasecopilot-ai-artifacts
-  s3_prefix: releasecopilot/
+  s3_prefix: releasecopilot
   secrets:
     jira: releasecopilot-ai/jira
     bitbucket: releasecopilot-ai/bitbucket

--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def load_dotenv(*, dotenv_path: str | os.PathLike[str] | None = None, **_: Any) -> bool:
+    """Lightweight fallback loader that mimics python-dotenv for tests."""
+
+    path = Path(dotenv_path) if dotenv_path else Path.cwd() / ".env"
+    if not path.exists():
+        return False
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ[key] = value
+    return True
+
+
+__all__ = ["load_dotenv"]

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -9,6 +9,13 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+SRC_PATH = ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(1, str(SRC_PATH))
+
 try:  # pragma: no cover - optional dependency loading
     from dotenv import load_dotenv
 
@@ -39,7 +46,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--freeze-date", help="ISO freeze date override")
     parser.add_argument("--window-days", type=int, default=28, help="Lookback window in days")
     parser.add_argument("--use-cache", action="store_true", help="Reuse cached payloads")
-    parser.add_argument("--upload-s3", action="store_true", help="Upload results to S3")
     parser.add_argument("--s3-bucket", help="Override destination S3 bucket")
     parser.add_argument("--s3-prefix", help="Override destination S3 prefix")
     parser.add_argument("--output-prefix", default="audit_results", help="Basename for generated files")
@@ -59,7 +65,6 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> tuple[argparse.Namespace
         window_days=args.window_days,
         freeze_date=args.freeze_date,
         develop_only=args.develop_only,
-        upload_s3=args.upload_s3,
         use_cache=args.use_cache,
         s3_bucket=args.s3_bucket or os.getenv("ARTIFACTS_BUCKET"),
         s3_prefix=args.s3_prefix,

--- a/src/releasecopilot/config.py
+++ b/src/releasecopilot/config.py
@@ -20,6 +20,8 @@ KNOWN_CONFIG_KEYS: set[str] = {
     "jira_base",
     "jira_token",
     "jira_user",
+    "s3_bucket",
+    "s3_prefix",
     "use_aws_secrets_manager",
 }
 

--- a/src/releasecopilot/uploader.py
+++ b/src/releasecopilot/uploader.py
@@ -1,0 +1,103 @@
+"""Utilities for uploading audit artifacts to Amazon S3."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+
+def build_s3_client(*, region_name: Optional[str] = None):
+    """Return a boto3 S3 client configured for ``region_name``."""
+
+    return boto3.client("s3", region_name=region_name)
+
+
+def upload_directory(
+    bucket: str,
+    prefix: str,
+    local_dir: Path | str,
+    subdir: str,
+    *,
+    client=None,
+    region_name: Optional[str] = None,
+    metadata: Optional[Dict[str, str]] = None,
+) -> None:
+    """Upload the contents of ``local_dir`` into ``s3://bucket/prefix/subdir``.
+
+    Parameters
+    ----------
+    bucket:
+        Destination S3 bucket.
+    prefix:
+        Base prefix for the upload (without the trailing ``subdir``).
+    local_dir:
+        Directory whose files will be uploaded.
+    subdir:
+        Name of the subdirectory to append under ``prefix`` (e.g. ``"reports"``).
+    client:
+        Optional boto3 S3 client. When omitted, a client is created using
+        :func:`build_s3_client` and ``region_name``.
+    region_name:
+        AWS region for the boto3 client when ``client`` is not supplied.
+    metadata:
+        Optional metadata dictionary to attach to every object.
+    """
+
+    base_path = Path(local_dir)
+    if not base_path.exists():
+        logger.info("Local directory %s does not exist; skipping upload.", base_path)
+        return
+
+    files = [path for path in sorted(base_path.rglob("*")) if path.is_file()]
+    if not files:
+        logger.info("No files found in %s; nothing to upload.", base_path)
+        return
+
+    client = client or build_s3_client(region_name=region_name)
+
+    normalized_prefix = prefix.strip("/")
+    normalized_subdir = subdir.strip("/")
+    combined_prefix = "/".join(filter(None, [normalized_prefix, normalized_subdir]))
+
+    normalized_metadata = {
+        key: str(value)
+        for key, value in (metadata or {}).items()
+        if value is not None
+    }
+
+    for file_path in files:
+        relative_key = file_path.relative_to(base_path)
+        key = "/".join(
+            filter(None, [combined_prefix, str(relative_key).replace("\\", "/")])
+        )
+        extra_args = {"ServerSideEncryption": "AES256"}
+        if normalized_metadata:
+            extra_args["Metadata"] = normalized_metadata
+        content_type = _guess_content_type(file_path)
+        if content_type:
+            extra_args["ContentType"] = content_type
+
+        try:
+            client.upload_file(str(file_path), bucket, key, ExtraArgs=extra_args)
+        except (BotoCoreError, ClientError):  # pragma: no cover - network failure path
+            logger.exception("Failed to upload %s to s3://%s/%s", file_path, bucket, key)
+            raise
+        logger.info("Uploaded %s to s3://%s/%s", file_path, bucket, key)
+
+
+def _guess_content_type(path: Path) -> Optional[str]:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "application/json"
+    if suffix in {".xls", ".xlsx"}:
+        return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    return None
+
+
+__all__ = ["build_s3_client", "upload_directory"]
+

--- a/tests/unit/test_main_upload.py
+++ b/tests/unit/test_main_upload.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+
+import importlib
+import importlib.util
+
+import pytest
+
+
+@pytest.fixture
+def main_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    root_str = str(root)
+    if root_str in sys.path:
+        sys.path.remove(root_str)
+    sys.path.insert(0, root_str)
+    src_path = root / "src"
+    src_str = str(src_path)
+    if src_str in sys.path:
+        sys.path.remove(src_str)
+    sys.path.insert(1, src_str)
+
+    monkeypatch.delitem(sys.modules, "config", raising=False)
+    monkeypatch.delitem(sys.modules, "config.settings", raising=False)
+    monkeypatch.delitem(sys.modules, "main", raising=False)
+
+    config_module = importlib.import_module("config.settings")
+    sys.modules["config.settings"] = config_module
+
+    spec = importlib.util.spec_from_file_location("main", root / "main.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Unable to load main module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["main"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fixed_datetime(monkeypatch: pytest.MonkeyPatch, main_module: types.ModuleType) -> None:
+    class FixedDatetime(datetime):
+        @classmethod
+        def utcnow(cls) -> "FixedDatetime":  # type: ignore[override]
+            return cls(2025, 10, 24, 15, 30, 0)
+
+    monkeypatch.setattr(main_module, "datetime", FixedDatetime)
+
+
+def test_upload_artifacts_builds_versioned_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    main_module: types.ModuleType,
+    fixed_datetime,
+) -> None:
+    reports = []
+    raw_files = []
+    for name in ("report.json", "report.xlsx", "summary.json"):
+        path = tmp_path / name
+        path.write_text("data", encoding="utf-8")
+        reports.append(path)
+    for name in ("jira.json", "commits.json", "cache.json"):
+        path = tmp_path / name
+        path.write_text("data", encoding="utf-8")
+        raw_files.append(path)
+
+    temp_dir = tmp_path / "temp"
+    monkeypatch.setattr(main_module, "TEMP_DIR", temp_dir)
+    monkeypatch.setattr(main_module, "_detect_git_sha", lambda: "abcdef123456")
+
+    calls: list[dict] = []
+
+    def fake_build_client(*, region_name=None):
+        return "client"
+
+    def fake_upload_directory(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(main_module.uploader, "build_s3_client", fake_build_client)
+    monkeypatch.setattr(main_module.uploader, "upload_directory", fake_upload_directory)
+
+    config = main_module.AuditConfig(fix_version="2025.10.24", s3_bucket="bucket", s3_prefix="audits")
+    settings = {"aws": {}}
+
+    main_module.upload_artifacts(
+        config=config,
+        settings=settings,
+        reports=reports,
+        raw_files=raw_files,
+        region="us-east-1",
+    )
+
+    assert len(calls) == 2
+
+    expected_prefix = "audits/2025.10.24/2025-10-24_153000"
+    assert {call["subdir"] for call in calls} == {"reports", "raw"}
+    for call in calls:
+        assert call["bucket"] == "bucket"
+        assert call["prefix"] == expected_prefix
+        assert call["client"] == "client"
+        metadata = call["metadata"]
+        assert metadata["fix-version"] == "2025.10.24"
+        assert metadata["generated-at"] == "2025-10-24T15:30:00Z"
+        assert metadata["git-sha"] == "abcdef123456"
+
+
+def test_upload_artifacts_skips_when_bucket_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    main_module: types.ModuleType,
+) -> None:
+    monkeypatch.setattr(main_module, "TEMP_DIR", tmp_path / "temp")
+
+    calls: list[dict] = []
+    monkeypatch.setattr(main_module.uploader, "upload_directory", lambda **kwargs: calls.append(kwargs))
+
+    config = main_module.AuditConfig(fix_version="2025.10.24")
+    settings = {"aws": {}}
+
+    main_module.upload_artifacts(
+        config=config,
+        settings=settings,
+        reports=[],
+        raw_files=[],
+        region=None,
+    )
+
+    assert calls == []

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from releasecopilot import uploader
+
+
+class StubS3Client:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def upload_file(self, filename: str, bucket: str, key: str, ExtraArgs: dict) -> None:  # noqa: N802 - boto3 signature
+        self.calls.append(
+            {
+                "filename": filename,
+                "bucket": bucket,
+                "key": key,
+                "extra_args": ExtraArgs,
+            }
+        )
+
+
+def test_upload_directory_builds_versioned_keys(tmp_path: Path) -> None:
+    base = tmp_path / "reports"
+    base.mkdir()
+    (base / "report.json").write_text("{}", encoding="utf-8")
+    nested = base / "nested"
+    nested.mkdir()
+    (nested / "raw.xlsx").write_bytes(b"binary")
+
+    client = StubS3Client()
+
+    uploader.upload_directory(
+        "my-bucket",
+        "audits/2025.10.24/2025-10-24_153000",
+        base,
+        "reports",
+        client=client,
+        metadata={"fix-version": "2025.10.24"},
+    )
+
+    keys = {call["key"]: call for call in client.calls}
+    assert "audits/2025.10.24/2025-10-24_153000/reports/report.json" in keys
+    assert "audits/2025.10.24/2025-10-24_153000/reports/nested/raw.xlsx" in keys
+
+    json_call = keys["audits/2025.10.24/2025-10-24_153000/reports/report.json"]
+    assert json_call["extra_args"]["ServerSideEncryption"] == "AES256"
+    assert json_call["extra_args"]["Metadata"]["fix-version"] == "2025.10.24"
+    assert json_call["extra_args"]["ContentType"] == "application/json"
+
+
+def test_upload_directory_skips_missing_directory(tmp_path: Path) -> None:
+    client = StubS3Client()
+
+    uploader.upload_directory(
+        "bucket",
+        "prefix",
+        tmp_path / "missing",
+        "reports",
+        client=client,
+    )
+
+    assert client.calls == []


### PR DESCRIPTION
## Summary
- add a reusable uploader helper that sends staged report and raw files to S3 with SSE-S3 and metadata
- update the main audit flow and CLI to build versioned prefixes and skip uploads when no bucket is configured
- document the new S3 layout, adjust defaults, and provide unit tests plus a lightweight dotenv stub for test runs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1d19b000c832fb91c5292df99bee9