### PR TITLE
Add targeted tests and mark binary golden artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/golden/audit_results.xlsx binary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Shared pytest fixtures for Release Copilot tests."""
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent network access during the test suite.
+
+    Several modules rely on optional network calls (e.g. fetching secrets).
+    Tests should never reach out to external services, so we patch the most
+    common socket entry points to raise a helpful error if triggered.
+    """
+
+    def _guard(*args: object, **kwargs: object) -> socket.socket:  # type: ignore[override]
+        raise RuntimeError("Network access is disabled during tests.")
+
+    monkeypatch.setattr(socket, "socket", _guard)
+    monkeypatch.setattr(socket, "create_connection", _guard)
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    """Return the path to the shared fixtures directory."""
+
+    return Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def load_json() -> "LoadJSONFn":
+    """Helper fixture to load JSON fixtures by filename."""
+
+    def _loader(path: str | Path) -> Dict[str, Any]:
+        file_path = Path(path)
+        with file_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    return _loader
+
+
+class LoadJSONFn:
+    """Protocol-like helper for typing the ``load_json`` fixture."""
+
+    def __call__(self, path: str | Path) -> Dict[str, Any]:  # pragma: no cover - documentation only
+        ...

--- a/tests/fixtures/commits.json
+++ b/tests/fixtures/commits.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "abc123",
+    "linkedStoryKeys": ["STORY-1"]
+  },
+  {
+    "id": "def456",
+    "linkedStoryKeys": []
+  }
+]

--- a/tests/fixtures/links.json
+++ b/tests/fixtures/links.json
@@ -1,0 +1,7 @@
+[
+  {
+    "source": "STORY-1",
+    "target": "def456",
+    "type": "relates_to"
+  }
+]

--- a/tests/fixtures/stories.json
+++ b/tests/fixtures/stories.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "STORY-1",
+    "status": "In Progress",
+    "assignee": "Alice",
+    "commitIds": ["abc123"]
+  },
+  {
+    "key": "STORY-2",
+    "status": "Done",
+    "assignee": "Bob",
+    "commitIds": []
+  }
+]

--- a/tests/golden/exporter_expected.json
+++ b/tests/golden/exporter_expected.json
@@ -1,0 +1,37 @@
+{
+  "stories": [
+    {
+      "key": "STORY-1",
+      "status": "In Progress",
+      "assignee": "Alice",
+      "commitIds": [
+        "abc123"
+      ]
+    },
+    {
+      "key": "STORY-2",
+      "status": "Done",
+      "assignee": "Bob",
+      "commitIds": []
+    }
+  ],
+  "commits": [
+    {
+      "id": "abc123",
+      "linkedStoryKeys": [
+        "STORY-1"
+      ]
+    },
+    {
+      "id": "def456",
+      "linkedStoryKeys": []
+    }
+  ],
+  "links": [
+    {
+      "source": "STORY-1",
+      "target": "def456",
+      "type": "relates_to"
+    }
+  ]
+}

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,45 @@
+"""CLI parsing tests for Release Copilot."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from releasecopilot import cli
+
+
+def test_parse_args_supports_boolean_flags() -> None:
+    """The CLI should toggle the AWS Secrets Manager flag correctly."""
+
+    args = cli.parse_args(["--use-aws-secrets-manager"])
+    assert args.use_aws_secrets_manager is True
+
+    args = cli.parse_args(["--no-aws-secrets-manager"])
+    assert args.use_aws_secrets_manager is False
+
+
+def test_parse_args_records_config_path(tmp_path: Path) -> None:
+    """Supplying ``--config`` should preserve the provided path."""
+
+    config_path = tmp_path / "custom.yaml"
+    args = cli.parse_args(["--config", str(config_path)])
+    assert Path(args.config) == config_path
+
+
+def test_run_builds_config_from_yaml(tmp_path: Path) -> None:
+    """``cli.run`` should integrate with ``build_config`` to produce a final mapping."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        fix_version: 8.8.8
+        jira_base: https://jira.cli
+        bitbucket_base: https://bitbucket.cli
+        use_aws_secrets_manager: false
+        """
+    )
+
+    result = cli.run(["--config", str(config_file)])
+
+    assert result["fix_version"] == "8.8.8"
+    assert result["jira_base"] == "https://jira.cli"
+    assert result["bitbucket_base"] == "https://bitbucket.cli"
+    assert result["config_path"] == str(config_file)

--- a/tests/test_config_precedence.py
+++ b/tests/test_config_precedence.py
@@ -1,0 +1,157 @@
+"""Configuration precedence and validation tests."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from releasecopilot.config import ConfigError, build_config, load_yaml_defaults
+
+
+def _namespace(**overrides: object) -> argparse.Namespace:
+    """Helper to construct CLI namespaces with sensible defaults."""
+
+    defaults = {
+        "config": None,
+        "fix_version": None,
+        "jira_base": None,
+        "bitbucket_base": None,
+        "jira_user": None,
+        "jira_token": None,
+        "bitbucket_token": None,
+        "use_aws_secrets_manager": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_load_yaml_defaults_reads_mapping(tmp_path: Path) -> None:
+    """``load_yaml_defaults`` should load structured data from YAML files."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        fix_version: 2.3.4
+        jira_base: https://jira.example.com
+        bitbucket_base: https://bitbucket.example.com
+        use_aws_secrets_manager: false
+        """
+    )
+
+    data = load_yaml_defaults(config_file)
+    assert data["fix_version"] == "2.3.4"
+    assert data["jira_base"] == "https://jira.example.com"
+    assert data["bitbucket_base"] == "https://bitbucket.example.com"
+    assert data["use_aws_secrets_manager"] is False
+
+
+def test_environment_variables_override_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables should take precedence over YAML defaults."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        fix_version: 1.0.0
+        jira_base: https://jira-from-file
+        bitbucket_base: https://bitbucket-from-file
+        jira_user: example@example.com
+        use_aws_secrets_manager: false
+        """
+    )
+
+    monkeypatch.setenv("RELEASECOPILOT_JIRA_BASE", "https://jira-from-env")
+    monkeypatch.setenv("BITBUCKET_BASE", "https://bitbucket-from-env")
+    monkeypatch.setenv("USE_AWS_SECRETS_MANAGER", "true")
+
+    args = _namespace(config=str(config_file))
+    config = build_config(args)
+
+    assert config["config_path"] == str(config_file)
+    assert config["jira_base"] == "https://jira-from-env"
+    assert config["bitbucket_base"] == "https://bitbucket-from-env"
+    assert config["use_aws_secrets_manager"] is True
+
+
+def test_cli_arguments_override_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """CLI arguments supplied by the user should have the highest precedence."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        fix_version: 3.0.0
+        jira_base: https://jira-from-file
+        bitbucket_base: https://bitbucket-from-file
+        use_aws_secrets_manager: false
+        """
+    )
+
+    monkeypatch.setenv("JIRA_BASE", "https://jira-from-env")
+
+    args = _namespace(
+        config=str(config_file),
+        jira_base="https://jira-from-cli",
+        fix_version="9.9.9",
+    )
+    config = build_config(args)
+
+    assert config["jira_base"] == "https://jira-from-cli"
+    assert config["fix_version"] == "9.9.9"
+
+
+def test_missing_required_fields_raise_config_error(tmp_path: Path) -> None:
+    """Missing required configuration values should raise ``ConfigError``."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        jira_base: https://jira.example.com
+        use_aws_secrets_manager: false
+        """
+    )
+
+    args = _namespace(config=str(config_file))
+    with pytest.raises(ConfigError) as excinfo:
+        build_config(args)
+
+    message = str(excinfo.value)
+    assert "fix_version" in message
+    assert "bitbucket_base" in message
+
+
+def test_invalid_yaml_type_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Non-mapping YAML content should surface as a ``ConfigError``."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text("- not-a-mapping\n- still-not-a-mapping\n")
+
+    args = _namespace(config=str(config_file))
+
+    with pytest.raises(ConfigError):
+        build_config(args)
+
+
+def test_environment_boolean_coercion(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Boolean configuration keys should respect truthy/falsy environment values."""
+
+    config_file = tmp_path / "releasecopilot.yaml"
+    config_file.write_text(
+        """
+        fix_version: 1.2.3
+        jira_base: https://jira.example.com
+        bitbucket_base: https://bitbucket.example.com
+        use_aws_secrets_manager: false
+        """
+    )
+
+    monkeypatch.setenv("USE_AWS_SECRETS_MANAGER", "0")
+
+    args = _namespace(config=str(config_file), use_aws_secrets_manager=True)
+    config = build_config(args)
+
+    assert config["use_aws_secrets_manager"] is True
+
+    monkeypatch.delenv("USE_AWS_SECRETS_MANAGER")
+    args = _namespace(config=str(config_file))
+    config = build_config(args)
+    assert config["use_aws_secrets_manager"] is False

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,76 @@
+"""Unit tests for deterministic diffing of audit runs."""
+from __future__ import annotations
+
+from tracking.diff import diff_runs
+
+
+def test_diff_runs_returns_sorted_changes() -> None:
+    """``diff_runs`` should produce predictable ordering for all sections."""
+
+    old_run = {
+        "stories": [
+            {
+                "key": "STORY-1",
+                "status": "In Progress",
+                "assignee": "Alice",
+                "commitIds": ["a1"],
+            },
+            {
+                "key": "STORY-2",
+                "status": "Review",
+                "assignee": "Bob",
+                "commitIds": ["legacy"],
+            },
+        ],
+        "commits": [
+            {"id": "a1", "linkedStoryKeys": ["STORY-1"]},
+            {"id": "legacy", "linkedStoryKeys": ["STORY-2"]},
+            {"id": "orphan-old", "linkedStoryKeys": []},
+        ],
+    }
+
+    new_run = {
+        "stories": [
+            {
+                "key": "STORY-1",
+                "status": "Done",
+                "assignee": "Charlie",
+                "commitIds": ["a1", "b2"],
+            },
+            {
+                "key": "STORY-3",
+                "status": "In Progress",
+                "assignee": "Dana",
+                "commitIds": ["c3"],
+            },
+        ],
+        "commits": [
+            {"id": "a1", "linkedStoryKeys": ["STORY-1"]},
+            {"id": "b2", "linkedStoryKeys": ["STORY-1"]},
+            {"id": "c3", "linkedStoryKeys": ["STORY-3"]},
+            {"id": "orphan-new", "linkedStoryKeys": []},
+        ],
+    }
+
+    diff = diff_runs(old_run, new_run)
+
+    assert diff["stories_added"] == ["STORY-3"]
+    assert diff["stories_removed"] == ["STORY-2"]
+    assert diff["status_changes"] == [
+        {"key": "STORY-1", "from": "In Progress", "to": "Done"}
+    ]
+    assert diff["assignee_changes"] == [
+        {"key": "STORY-1", "from": "Alice", "to": "Charlie"}
+    ]
+    assert diff["commits_added"] == [
+        {"key": "STORY-1", "commit_ids": ["b2"]},
+        {"key": "STORY-3", "commit_ids": ["c3"]},
+    ]
+    assert diff["commits_removed"] == [
+        {"key": "STORY-2", "commit_ids": ["legacy"]}
+    ]
+    assert diff["new_orphans"] == ["orphan-new"]
+    assert diff["resolved_orphans"] == ["orphan-old"]
+    assert diff["coverage_previous"] == 100.0
+    assert diff["coverage_current"] == 100.0
+    assert diff["coverage_delta"] == 0.0

--- a/tests/test_exporter_golden.py
+++ b/tests/test_exporter_golden.py
@@ -1,0 +1,30 @@
+"""Golden-file verification tests for the JSON exporter."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exporters.json_exporter import JSONExporter
+
+
+def test_json_exporter_produces_expected_payload(
+    tmp_path, fixtures_dir, load_json
+) -> None:
+    """Exported JSON should match the golden artifact byte-for-byte."""
+
+    payload = {
+        "stories": load_json(fixtures_dir / "stories.json"),
+        "commits": load_json(fixtures_dir / "commits.json"),
+        "links": load_json(fixtures_dir / "links.json"),
+    }
+
+    exporter = JSONExporter(tmp_path)
+    output_path = exporter.export(payload, filename="golden.json")
+
+    golden_path = Path(__file__).resolve().parent / "golden" / "exporter_expected.json"
+
+    output_text = output_path.read_text(encoding="utf-8").strip()
+    golden_text = golden_path.read_text(encoding="utf-8").strip()
+
+    assert output_text == golden_text
+    assert json.loads(output_text) == json.loads(golden_text)


### PR DESCRIPTION
## Summary
- mark the Excel audit result as binary via .gitattributes to avoid diff errors
- add pytest fixtures, sample JSON data, and a golden artifact for exporter validation
- introduce focused tests for configuration precedence, exporter output, diff stability, and CLI argument handling

## Testing
- pytest tests/test_config_precedence.py tests/test_exporter_golden.py tests/test_diff.py tests/test_cli_args.py

------
https://chatgpt.com/codex/tasks/task_e_68d1e220ba5c832f90494160b617f31b