### PR TITLE
feat(cdk): codify core infra stack

### DIFF
--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,0 +1,44 @@
+# AWS baseline and CDK migration
+
+## Manual setup recap
+
+The initial Release Copilot proof-of-concept relied on a manually provisioned IAM execution role with temporary `AdministratorAccess`/`FullAccess` policies, an S3 bucket configured for artifact storage, and Secrets Manager entries for Jira and Bitbucket OAuth credentials. Those steps enabled the prototype but left broad permissions in place and required console-driven configuration management.
+
+## CDK-managed equivalent
+
+The new CDK `CoreStack` codifies those resources with least-privilege defaults:
+
+- **S3 artifacts bucket** &mdash; server-side encrypted with AWS-managed keys, versioned, and non-public. Lifecycle management moves `raw/` objects to Standard-IA after 30 days and deletes them after 90 days, while `reports/` objects move to Standard-IA after 60 days and are retained indefinitely.
+- **Secrets** &mdash; existing Jira and Bitbucket secrets can be imported by ARN; when omitted the stack creates placeholders using `SecretStringGenerator` so synthesis/deployment succeed without pre-provisioned secrets.
+- **Lambda execution role** &mdash; grants only the actions required to write logs, list the bucket within the `releasecopilot/` prefix, read/write prefixed objects, and fetch the two exact secrets. The Lambda receives environment variables (`RC_S3_BUCKET`, `RC_S3_PREFIX`, `RC_USE_AWS_SECRETS_MANAGER`) that mirror the manual configuration but are now centrally defined.
+- **Outputs** &mdash; expose the bucket name and Lambda identifiers for downstream wiring. Future enhancements (for example an EventBridge schedule driven by `scheduleEnabled`/`scheduleCron` context flags) can attach to the Lambda without altering these foundations.
+
+## Migration guidance
+
+1. Deploy the CDK stack in a sandbox account and validate artifact uploads, secret retrieval, and Lambda execution logs.
+2. Once validated, deploy to the production account. The stack will create or import the necessary secrets, enforce lifecycle policies, and provision the least-privilege execution role.
+3. After the production deployment is confirmed, detach the temporary `FullAccess` policies from the original console-managed role or switch workloads to the CDK-managed role entirely.
+
+## Quick runbook
+
+```bash
+# one-time setup
+cd infra/cdk
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\Activate
+pip install -r requirements.txt
+cdk bootstrap
+
+# synth & test
+pytest -q
+cdk synth
+
+# deploy with defaults
+cdk deploy --require-approval never
+
+# override context for real bucket + secrets
+cdk deploy \
+  --context region=us-west-2 \
+  --context bucketName=releasecopilot-artifacts-slv \
+  --context jiraSecretArn=arn:aws:secretsmanager:us-west-2:ACCOUNT:secret:/releasecopilot/jira-XXXX \
+  --context bitbucketSecretArn=arn:aws:secretsmanager:us-west-2:ACCOUNT:secret:/releasecopilot/bitbucket-YYYY
+```

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -2,15 +2,14 @@
   "app": "python3 app.py",
   "context": {
     "env": "dev",
-    "project": "releasecopilot",
-    "bucketBase": "releasecopilot-audit",
-    "reportPrefix": "reports/",
-    "rawPrefix": "raw/",
-    "logLevel": "INFO",
-    "lambdaModule": "aws.core_handler",
-    "secrets": {
-      "jira": "rc/jira",
-      "bitbucket": "rc/bitbucket"
-    }
+    "region": "us-west-2",
+    "bucketName": "",
+    "jiraSecretArn": "",
+    "bitbucketSecretArn": "",
+    "lambdaAssetPath": "../../dist",
+    "lambdaHandler": "main.handler",
+    "rcS3Prefix": "releasecopilot",
+    "lambdaTimeoutSec": 180,
+    "lambdaMemoryMb": 512
   }
 }

--- a/infra/cdk/requirements.txt
+++ b/infra/cdk/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk-lib==2.*
+constructs>=10.0.0,<11.0.0
+pytest

--- a/tests/infra/test_core_stack.py
+++ b/tests/infra/test_core_stack.py
@@ -1,0 +1,133 @@
+"""Unit tests validating the CDK core stack resources."""
+from __future__ import annotations
+
+from aws_cdk import App
+from aws_cdk.assertions import Match, Template
+
+from infra.cdk.core_stack import CoreStack
+
+
+JIRA_ARN = "arn:aws:secretsmanager:us-west-2:111111111111:secret:/releasecopilot/jira-ABC123"
+BITBUCKET_ARN = "arn:aws:secretsmanager:us-west-2:111111111111:secret:/releasecopilot/bitbucket-DEF456"
+
+
+def _synth_template() -> Template:
+    app = App()
+    stack = CoreStack(
+        app,
+        "TestCoreStack",
+        bucket_name="releasecopilot-artifacts-111111111111",
+        jira_secret_arn=JIRA_ARN,
+        bitbucket_secret_arn=BITBUCKET_ARN,
+        lambda_asset_path="dist",
+        rc_s3_prefix="releasecopilot",
+    )
+    return Template.from_stack(stack)
+
+
+def test_bucket_encryption_and_versioning() -> None:
+    template = _synth_template()
+    template.has_resource_properties(
+        "AWS::S3::Bucket",
+        {
+            "VersioningConfiguration": {"Status": "Enabled"},
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": Match.array_with([
+                    Match.object_like({"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}})
+                ])
+            },
+        },
+    )
+
+
+def test_bucket_lifecycle_rules() -> None:
+    template = _synth_template()
+    buckets = template.find_resources("AWS::S3::Bucket")
+    assert len(buckets) == 1
+    bucket_props = next(iter(buckets.values()))["Properties"]
+    lifecycle_rules = bucket_props["LifecycleConfiguration"]["Rules"]
+
+    raw_rule = next(rule for rule in lifecycle_rules if rule["Prefix"] == "raw/")
+    assert raw_rule["ExpirationInDays"] == 90
+    assert raw_rule["Transitions"] == [
+        {"StorageClass": "STANDARD_IA", "TransitionInDays": 30}
+    ]
+
+    reports_rule = next(rule for rule in lifecycle_rules if rule["Prefix"] == "reports/")
+    assert "ExpirationInDays" not in reports_rule
+    assert reports_rule["Transitions"] == [
+        {"StorageClass": "STANDARD_IA", "TransitionInDays": 60}
+    ]
+
+
+def test_iam_policy_statements() -> None:
+    template = _synth_template()
+    policies = template.find_resources("AWS::IAM::Policy")
+    policy = next(
+        props
+        for props in policies.values()
+        if props["Properties"]["PolicyName"].startswith("LambdaExecutionPolicy")
+    )
+
+    statements = policy["Properties"]["PolicyDocument"]["Statement"]
+
+    logs_statement = next(
+        stmt
+        for stmt in statements
+        if isinstance(stmt.get("Action"), list)
+        and set(stmt["Action"]) == {
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+        }
+    )
+    assert logs_statement["Resource"] == "*"
+
+    list_statement = next(
+        stmt for stmt in statements if stmt.get("Action") == "s3:ListBucket"
+    )
+    assert list_statement["Condition"] == {"StringLike": {"s3:prefix": ["releasecopilot/"]}}
+    list_resource = list_statement["Resource"]
+    assert list_resource["Fn::GetAtt"][1] == "Arn"
+
+    object_statement = next(
+        stmt
+        for stmt in statements
+        if isinstance(stmt.get("Action"), list)
+        and set(stmt["Action"]) == {"s3:GetObject", "s3:PutObject"}
+    )
+    join_parts = object_statement["Resource"]["Fn::Join"][1]
+    bucket_part = join_parts[0]
+    assert bucket_part["Fn::GetAtt"][1] == "Arn"
+    assert join_parts[1] == "/releasecopilot/*"
+
+    secrets_statement = next(
+        stmt
+        for stmt in statements
+        if stmt.get("Action") == "secretsmanager:GetSecretValue"
+    )
+    assert secrets_statement["Resource"] == [JIRA_ARN, BITBUCKET_ARN]
+
+
+def test_lambda_environment_and_log_retention() -> None:
+    template = _synth_template()
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Handler": "main.handler",
+            "Environment": {
+                "Variables": Match.object_like(
+                    {
+                        "RC_S3_BUCKET": Match.any_value(),
+                        "RC_S3_PREFIX": "releasecopilot",
+                        "RC_USE_AWS_SECRETS_MANAGER": "true",
+                    }
+                )
+            },
+        },
+    )
+
+    template.has_resource_properties(
+        "Custom::LogRetention",
+        {"RetentionInDays": 30},
+    )


### PR DESCRIPTION
## Summary
- implement a CDK CoreStack with an encrypted/versioned artifacts bucket, lifecycle management, placeholder/imported secrets, least-privilege IAM role, and a configurable Lambda function with outputs
- read required context defaults in the CDK app and provide example defaults plus requirements for local usage
- document the AWS migration steps and add targeted assertions covering bucket, IAM, Lambda env, and log retention

## Testing
- pip install -r infra/cdk/requirements.txt
- pytest -q tests/infra/test_core_stack.py

------
https://chatgpt.com/codex/tasks/task_e_68d30643b39c832fb2da170ea88f5677