### PR TITLE
feat: add CDK core stack skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,18 @@ Published with MkDocs Material (auto-deployed from `main`):
 https://<your-github-username>.github.io/releasecopilot-ai
 
 Edit pages under `docs/` and push to `main` — the site republish is automated by GitHub Actions.
+
+### Deploying with CDK (dev)
+
+```bash
+cd infra/cdk
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\Activate
+pip install -r requirements.txt
+cdk bootstrap
+pytest -q
+cdk synth
+cdk deploy --require-approval never
+
+# override context if needed
+cdk deploy   --context bucketBase=releasecopilot-artifacts   --context jiraSecretArn=arn:aws:secretsmanager:...   --context bitbucketSecretArn=arn:aws:secretsmanager:...
+```

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -3,13 +3,12 @@
   "context": {
     "env": "dev",
     "region": "us-west-2",
-    "bucketName": "",
-    "jiraSecretArn": "",
-    "bitbucketSecretArn": "",
+    "bucketBase": "releasecopilot-artifacts",
     "lambdaAssetPath": "../../dist",
     "lambdaHandler": "main.handler",
-    "rcS3Prefix": "releasecopilot",
-    "lambdaTimeoutSec": 180,
-    "lambdaMemoryMb": 512
+    "jiraSecretArn": "",
+    "bitbucketSecretArn": "",
+    "scheduleEnabled": false,
+    "scheduleCron": "cron(30 1 * * ? *)"
   }
 }

--- a/infra/cdk/core_stack.py
+++ b/infra/cdk/core_stack.py
@@ -1,4 +1,4 @@
-"""CDK stack defining the Release Copilot core infrastructure."""
+"""CDK stack defining the ReleaseCopilot core infrastructure."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -18,7 +18,9 @@ from constructs import Construct
 
 
 class CoreStack(Stack):
-    """Provision the Release Copilot storage, secrets, and execution runtime."""
+    """Provision the ReleaseCopilot storage, secrets, and execution runtime."""
+
+    RC_S3_PREFIX = "releasecopilot"
 
     def __init__(
         self,
@@ -30,15 +32,15 @@ class CoreStack(Stack):
         bitbucket_secret_arn: Optional[str] = None,
         lambda_asset_path: str = "../../dist",
         lambda_handler: str = "main.handler",
-        rc_s3_prefix: str = "releasecopilot",
         lambda_timeout_sec: int = 180,
         lambda_memory_mb: int = 512,
+        schedule_enabled: bool = False,
+        schedule_cron: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         asset_path = Path(lambda_asset_path).expanduser().resolve()
-        normalized_prefix = self._normalize_prefix(rc_s3_prefix)
 
         self.bucket = s3.Bucket(
             self,
@@ -50,7 +52,7 @@ class CoreStack(Stack):
         )
 
         self.bucket.add_lifecycle_rule(
-            id="RawLifecycle",
+            id="RawArtifactsLifecycle",
             prefix="raw/",
             transitions=[
                 s3.Transition(
@@ -75,54 +77,31 @@ class CoreStack(Stack):
         self.jira_secret = self._resolve_secret(
             "JiraSecret",
             provided_arn=jira_secret_arn,
-            description="Placeholder Jira OAuth secret for Release Copilot",
+            description="Placeholder Jira OAuth secret for ReleaseCopilot",
         )
         self.bitbucket_secret = self._resolve_secret(
             "BitbucketSecret",
             provided_arn=bitbucket_secret_arn,
-            description="Placeholder Bitbucket OAuth secret for Release Copilot",
+            description="Placeholder Bitbucket OAuth secret for ReleaseCopilot",
         )
-        secret_arns = [
-            self.jira_secret.secret_arn,
-            self.bitbucket_secret.secret_arn,
-        ]
 
         self.execution_role = iam.Role(
             self,
             "LambdaExecutionRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            description="Least-privilege execution role for Release Copilot Lambda",
+            description="Least-privilege execution role for ReleaseCopilot Lambda",
         )
 
-        iam.Policy(
-            self,
-            "LambdaExecutionPolicy",
-            statements=[
-                iam.PolicyStatement(
-                    actions=["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-                    resources=["*"],
-                ),
-                iam.PolicyStatement(
-                    actions=["s3:ListBucket"],
-                    resources=[self.bucket.bucket_arn],
-                    conditions={"StringLike": {"s3:prefix": [f"{normalized_prefix}/"]}},
-                ),
-                iam.PolicyStatement(
-                    actions=["s3:GetObject", "s3:PutObject"],
-                    resources=[self.bucket.arn_for_objects(f"{normalized_prefix}/*")],
-                ),
-                iam.PolicyStatement(
-                    actions=["secretsmanager:GetSecretValue"],
-                    resources=secret_arns,
-                ),
-            ],
-        ).attach_to_role(self.execution_role)
+        self._attach_policies()
 
         environment = {
             "RC_S3_BUCKET": self.bucket.bucket_name,
-            "RC_S3_PREFIX": normalized_prefix,
+            "RC_S3_PREFIX": self.RC_S3_PREFIX,
             "RC_USE_AWS_SECRETS_MANAGER": "true",
         }
+
+        clamped_timeout = max(180, min(lambda_timeout_sec, 300))
+        clamped_memory = max(512, min(lambda_memory_mb, 1024))
 
         self.lambda_function = _lambda.Function(
             self,
@@ -130,24 +109,63 @@ class CoreStack(Stack):
             runtime=_lambda.Runtime.PYTHON_3_11,
             handler=lambda_handler,
             code=_lambda.Code.from_asset(str(asset_path)),
-            timeout=Duration.seconds(lambda_timeout_sec),
-            memory_size=lambda_memory_mb,
+            timeout=Duration.seconds(clamped_timeout),
+            memory_size=clamped_memory,
             role=self.execution_role,
             environment=environment,
             log_retention=logs.RetentionDays.ONE_MONTH,
         )
 
-        # EventBridge schedule wiring could be added later using context flags
+        # EventBridge schedule integration can be added in the future if required.
         CfnOutput(self, "ArtifactsBucketName", value=self.bucket.bucket_name)
         CfnOutput(self, "LambdaName", value=self.lambda_function.function_name)
         CfnOutput(self, "LambdaArn", value=self.lambda_function.function_arn)
 
-    @staticmethod
-    def _normalize_prefix(prefix: str) -> str:
-        stripped = prefix.strip()
-        if not stripped:
-            return "releasecopilot"
-        return stripped.strip("/")
+    def _attach_policies(self) -> None:
+        prefix_objects_arn = self.bucket.arn_for_objects(f"{self.RC_S3_PREFIX}/*")
+        log_group_arn = f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/*"
+
+        iam.Policy(
+            self,
+            "LambdaExecutionPolicy",
+            statements=[
+                iam.PolicyStatement(
+                    sid="AllowS3ObjectAccess",
+                    actions=["s3:GetObject", "s3:PutObject"],
+                    resources=[prefix_objects_arn],
+                ),
+                iam.PolicyStatement(
+                    sid="AllowS3ListArtifactsPrefix",
+                    actions=["s3:ListBucket"],
+                    resources=[self.bucket.bucket_arn],
+                    conditions={
+                        "StringLike": {
+                            "s3:prefix": [
+                                f"{self.RC_S3_PREFIX}/",
+                                f"{self.RC_S3_PREFIX}/*",
+                            ]
+                        }
+                    },
+                ),
+                iam.PolicyStatement(
+                    sid="AllowSecretRetrieval",
+                    actions=["secretsmanager:GetSecretValue"],
+                    resources=[
+                        self.jira_secret.secret_arn,
+                        self.bitbucket_secret.secret_arn,
+                    ],
+                ),
+                iam.PolicyStatement(
+                    sid="AllowLambdaLogging",
+                    actions=[
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents",
+                    ],
+                    resources=[log_group_arn],
+                ),
+            ],
+        ).attach_to_role(self.execution_role)
 
     def _resolve_secret(
         self,
@@ -165,6 +183,6 @@ class CoreStack(Stack):
             construct_id,
             description=description,
             generate_secret_string=secretsmanager.SecretStringGenerator(
-                exclude_punctuation=True
+                exclude_punctuation=True,
             ),
         )

--- a/infra/cdk/requirements.txt
+++ b/infra/cdk/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib==2.*
 constructs>=10.0.0,<11.0.0
 pytest
+pytest-cov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 pythonpath = src .
 testpaths = tests
+addopts = --import-mode=importlib
 markers =
     integration: integration-level recovery tool tests
 


### PR DESCRIPTION
## Summary
- implement CDK app entrypoint that derives per-account artifact bucket context and instantiates the new core stack
- provision ReleaseCopilot core stack with secure S3 bucket, secrets, Lambda execution role, and Python 3.11 function defaults
- update infrastructure tests and documentation for the CDK workflow, including pytest import mode configuration

## Testing
- `pytest -q`
- `cd infra/cdk && cdk synth`


------
https://chatgpt.com/codex/tasks/task_e_68d318cd3c50832f93e982e7645be4d2