### PR TITLE
Fix CDK synth workflow and environment resolution

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -12,16 +12,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install CDK CLI
         run: npm install -g aws-cdk@2
       - name: Install dependencies
-        run: pip install -r cdk/requirements.txt
+        run: pip install -r infra/cdk/requirements.txt
+      - name: Prepare CDK environment
+        id: cdk_env
+        run: |
+          ACCOUNT_ID="${{ secrets.CDK_DEFAULT_ACCOUNT }}"
+          REGION="${{ secrets.CDK_DEFAULT_REGION }}"
+          if [ -z "$REGION" ]; then
+            REGION="us-west-2"
+          fi
+          if [ -z "$ACCOUNT_ID" ]; then
+            ACCOUNT_ID="000000000000"
+          fi
+          echo "CDK_DEFAULT_ACCOUNT=$ACCOUNT_ID" >> "$GITHUB_ENV"
+          echo "CDK_DEFAULT_REGION=$REGION" >> "$GITHUB_ENV"
+          echo "AWS_REGION=$REGION" >> "$GITHUB_ENV"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+          echo "account=$ACCOUNT_ID" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS credentials
+        if: ${{ secrets.AWS_OIDC_ROLE_ARN != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ steps.cdk_env.outputs.region }}
       - name: CDK synth
-        working-directory: cdk
+        working-directory: infra/cdk
         run: cdk synth
       - name: CDK diff
-        working-directory: cdk
+        working-directory: infra/cdk
         run: cdk diff || true

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ Infrastructure for the audit workflow is defined in `infra/cdk`. Each AWS enviro
    - Add `--no-schedule` to disable the optional EventBridge rule regardless of the environment config.
 4. The script bootstraps the account if needed (`cdk bootstrap`) and then executes `cdk deploy --require-approval never` with the environment context derived from the configuration file.
 
+### Synth prerequisites
+
+`infra/cdk/app.py` automatically works out the deployment account and region, but `cdk synth` still needs one of the following to succeed:
+
+1. **CDK context:** supply `account`/`region` in `infra/cdk/cdk.json`, an `infra/envs/<env>.json` file, or via CLI flags, e.g. `cdk synth -c account=123456789012 -c region=us-west-2`.
+2. **AWS credentials:** run `aws configure`, `aws sso login`, or export environment variables so that `boto3` can call `sts:GetCallerIdentity`. The resolved identity is used for the CDK environment automatically.
+3. **Explicit environment variables:** export `CDK_DEFAULT_ACCOUNT` (and optionally `CDK_DEFAULT_REGION`) before invoking `cdk synth`.
+
+Any of the above options keeps local developer workflows working while ensuring CI has enough information to synthesise the stacks.
+
 Production buckets are retained by default; set `"retainBucket": false` in non-production configs to allow destruction on stack deletion.
 
 ## Secrets Management


### PR DESCRIPTION
## Summary
- run the CDK synth/diff workflow on Node 20, install infra dependencies, and set up environment defaults with optional AWS credential configuration
- let `infra/cdk/app.py` resolve the deployment account/region from context, boto3 identity, or environment variables without hard failures
- document the supported options developers can use to satisfy `cdk synth` prerequisites locally

## Testing
- python -m compileall infra/cdk/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3367b5594832faf079308d416e675