### PR TITLE
Add CloudWatch alarms for Lambda and optional SNS notifications

### DIFF
--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -42,3 +42,19 @@ cdk deploy \
   --context jiraSecretArn=arn:aws:secretsmanager:us-west-2:ACCOUNT:secret:/releasecopilot/jira-XXXX \
   --context bitbucketSecretArn=arn:aws:secretsmanager:us-west-2:ACCOUNT:secret:/releasecopilot/bitbucket-YYYY
 ```
+
+### Quick runbook: CloudWatch alarms
+
+```bash
+cd infra/cdk
+source .venv/bin/activate  # Windows: .venv\Scripts\Activate
+cdk synth
+
+# deploy without email
+cdk deploy --require-approval never
+
+# deploy with email notifications
+cdk deploy --context alarmEmail=you@example.com --require-approval never
+
+# smoke test: cause a Lambda error, re-invoke, then check CloudWatch Alarms
+```

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -9,6 +9,7 @@
     "jiraSecretArn": "",
     "bitbucketSecretArn": "",
     "scheduleEnabled": false,
-    "scheduleCron": "cron(30 1 * * ? *)"
+    "scheduleCron": "cron(30 1 * * ? *)",
+    "alarmEmail": ""
   }
 }


### PR DESCRIPTION
## Summary
- add CloudWatch error and throttle alarms to the core Lambda with optional SNS notifications via context
- expose a default `alarmEmail` context setting and document alarm deployment steps
- extend infrastructure unit tests to cover alarms, optional SNS resources, and log retention

## Testing
- pytest tests/infra/test_core_stack.py

------
https://chatgpt.com/codex/tasks/task_e_68d3cd420d44832f8f72d8368241ff28