### PR TITLE
Add optional EventBridge schedule for audit Lambda

### DIFF
--- a/infra/cdk/core_stack.py
+++ b/infra/cdk/core_stack.py
@@ -233,6 +233,11 @@ class CoreStack(Stack):
             throttles_alarm.add_alarm_action(action)
 
     def _add_schedule(self, *, schedule_enabled: bool, schedule_cron: str | None) -> None:
+        """Provision the optional EventBridge rule when scheduling is enabled.
+
+        Skipping creation when ``schedule_enabled`` is false ensures the stack
+        deletes any previously-deployed schedule during updates.
+        """
         if not schedule_enabled:
             return
 

--- a/tests/infra/test_core_stack.py
+++ b/tests/infra/test_core_stack.py
@@ -150,27 +150,33 @@ def test_stack_outputs_present() -> None:
     assert "LambdaArn" in outputs
 
 
-def test_schedule_rule_created_when_enabled() -> None:
+def test_eventbridge_rule_targets_lambda_when_enabled() -> None:
     template = _synth_template(
         schedule_enabled=True,
         schedule_cron="cron(0 12 * * ? *)",
     )
-    template.has_resource_properties(
-        "AWS::Events::Rule",
-        {
-            "ScheduleExpression": "cron(0 12 * * ? *)",
-            "State": "ENABLED",
-            "Targets": [
-                Match.object_like(
-                    {
-                        "Arn": {
-                            "Fn::GetAtt": [
-                                Match.string_like_regexp("ReleaseCopilotLambda.*"),
-                                "Arn",
-                            ],
-                        }
-                    }
-                )
-            ],
-        },
-    )
+
+    rules = template.find_resources("AWS::Events::Rule")
+    assert len(rules) == 1
+
+    rule = next(iter(rules.values()))
+    properties = rule["Properties"]
+
+    assert properties["ScheduleExpression"] == "cron(0 12 * * ? *)"
+    assert properties["State"] == "ENABLED"
+
+    targets = properties["Targets"]
+    assert len(targets) == 1
+
+    target = targets[0]
+    assert target["Id"] == "Target0"
+
+    arn_getatt = target["Arn"]["Fn::GetAtt"]
+    assert arn_getatt[1] == "Arn"
+    assert arn_getatt[0].startswith("ReleaseCopilotLambda")
+
+
+def test_eventbridge_rule_absent_when_schedule_disabled() -> None:
+    template = _synth_template(schedule_enabled=False)
+
+    assert template.find_resources("AWS::Events::Rule") == {}

--- a/tests/infra/test_core_stack.py
+++ b/tests/infra/test_core_stack.py
@@ -148,3 +148,29 @@ def test_stack_outputs_present() -> None:
     outputs = template.to_json()["Outputs"]
     assert "ArtifactsBucketName" in outputs
     assert "LambdaArn" in outputs
+
+
+def test_schedule_rule_created_when_enabled() -> None:
+    template = _synth_template(
+        schedule_enabled=True,
+        schedule_cron="cron(0 12 * * ? *)",
+    )
+    template.has_resource_properties(
+        "AWS::Events::Rule",
+        {
+            "ScheduleExpression": "cron(0 12 * * ? *)",
+            "State": "ENABLED",
+            "Targets": [
+                Match.object_like(
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                Match.string_like_regexp("ReleaseCopilotLambda.*"),
+                                "Arn",
+                            ],
+                        }
+                    }
+                )
+            ],
+        },
+    )


### PR DESCRIPTION
## Summary
- add optional EventBridge rule creation that targets the ReleaseCopilot Lambda when `scheduleEnabled` is true
- document how to enable, customize, or disable the cron-driven schedule via CDK context flags
- cover the EventBridge rule in infrastructure unit tests

## Testing
- `pytest tests/infra/test_core_stack.py`
- `cdk synth` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d444a59014832f847e6e936b256bc8