### PR TITLE
Add structured logging, retries, and typed errors

### DIFF
--- a/clients/base.py
+++ b/clients/base.py
@@ -2,21 +2,37 @@
 from __future__ import annotations
 
 import json
-import logging
+import os
+import random
+import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+import requests
+
+from releasecopilot.logging_config import get_logger, parse_retry_after
+
+logger = get_logger(__name__)
 
 
 class BaseAPIClient:
     """Base API client that persists raw responses for caching and auditing."""
 
+    _MAX_ATTEMPTS = 5
+    _BASE_DELAY = 1.0
+
     def __init__(self, cache_dir: Path | str) -> None:
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self._last_cache_files: dict[str, Path] = {}
+        self._random = random.Random()
+        self._retries_enabled = os.getenv("RC_DISABLE_RETRIES", "false").lower() not in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
     def _cache_response(self, name: str, payload: Any) -> Path:
         """Persist the raw payload with a timestamp for traceability."""
@@ -49,3 +65,85 @@ class BaseAPIClient:
     def get_last_cache_file(self, name: str) -> Optional[Path]:
         """Return the last cache file path for the provided name."""
         return self._last_cache_files.get(name)
+
+    # Networking ---------------------------------------------------------
+    def _sleep(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+    @staticmethod
+    def _is_retryable_status(status: int) -> bool:
+        return status == 429 or 500 <= status < 600
+
+    @staticmethod
+    def _is_retryable_exception(exc: requests.RequestException) -> bool:
+        retryable = (requests.Timeout, requests.ConnectionError)
+        if isinstance(exc, retryable):
+            return True
+        response = getattr(exc, "response", None)
+        if response is not None and BaseAPIClient._is_retryable_status(response.status_code):
+            return True
+        return False
+
+    def _compute_delay(self, attempt: int, response: requests.Response | None) -> float:
+        backoff = self._BASE_DELAY * (2 ** (attempt - 1))
+        jitter = self._random.uniform(0, backoff)
+        delay = backoff + jitter
+        if response is not None:
+            retry_after = parse_retry_after(response.headers.get("Retry-After", ""))
+            if retry_after is not None:
+                delay = max(delay, retry_after)
+        return delay
+
+    def _request_with_retry(
+        self,
+        *,
+        session: requests.Session,
+        method: str,
+        url: str,
+        logger_context: Dict[str, Any],
+        **kwargs: Any,
+    ) -> requests.Response:
+        max_attempts = self._MAX_ATTEMPTS if self._retries_enabled else 1
+        attempt = 1
+        while True:
+            context = dict(logger_context)
+            context.update({"method": method, "url": url, "attempt": attempt})
+            logger.debug("HTTP request", extra=context)
+            start = time.perf_counter()
+            try:
+                response = session.request(method=method, url=url, **kwargs)
+            except requests.RequestException as exc:
+                elapsed_ms = (time.perf_counter() - start) * 1000
+                context.update({"elapsed_ms": round(elapsed_ms, 2), "error": str(exc)})
+                if attempt >= max_attempts or not self._is_retryable_exception(exc):
+                    raise
+                delay = self._compute_delay(attempt, getattr(exc, "response", None))
+                context["retry_in_s"] = round(delay, 2)
+                logger.warning("Retrying after exception", extra=context)
+                self._sleep(delay)
+                attempt += 1
+                continue
+
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            headers = {key: value for key, value in response.headers.items() if key.lower().startswith("x-rate")}
+            response_context = dict(context)
+            response_context.update(
+                {
+                    "status_code": response.status_code,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                }
+            )
+            if headers:
+                response_context["rate_limit"] = headers
+            logger.debug("HTTP response", extra=response_context)
+
+            if self._is_retryable_status(response.status_code) and attempt < max_attempts:
+                delay = self._compute_delay(attempt, response)
+                retry_context = dict(response_context)
+                retry_context["retry_in_s"] = round(delay, 2)
+                logger.warning("Retrying after status", extra=retry_context)
+                self._sleep(delay)
+                attempt += 1
+                continue
+
+            return response

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,52 @@
+# Observability and Resilience
+
+ReleaseCopilot emits structured logs and automatically retries transient
+network failures. This guide documents the core controls.
+
+## Logging
+
+Logs are emitted through a central configuration that writes to `stdout` using
+ISO-8601 timestamps, module names, and the active correlation identifier.
+
+### Log levels
+
+* Default level is **INFO**. Use the `--log-level` CLI option or the
+  `RC_LOG_LEVEL` environment variable to change verbosity.
+* Levels follow the standard Python logging hierarchy:
+  `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+### JSON mode
+
+Set `RC_LOG_JSON=true` to switch the formatter to JSON. Each record includes
+`timestamp`, `level`, `logger`, `message`, and `correlation_id` plus any
+structured context supplied via `logger.extra`.
+
+### Correlation ID
+
+Each process run is tagged with a correlation identifier (`RC_CORR_ID`) that is
+included in every log line. A random UUID is generated when the variable is not
+set. Propagate the correlation ID across worker processes to preserve request
+traces.
+
+### Secret redaction
+
+Common secret tokens (e.g., values containing "token", "secret", "password",
+"key", or "authorization") are automatically redacted to prevent accidental
+exposure in logs.
+
+## Retry behaviour
+
+Jira and Bitbucket HTTP calls are protected with exponential backoff and
+jitter. Transient errors trigger up to five attempts when the response status
+is `429` or any `5xx`, or when a timeout/connection error occurs.
+
+* Backoff starts at one second and doubles on each attempt with random jitter.
+* `Retry-After` headers are honoured—delays never fall below the server hint.
+* Retry attempts are logged at the `WARNING` level with the request context
+  (HTTP method, URL, repository/JQL details) and rate-limit headers.
+
+### Disabling retries
+
+Set `RC_DISABLE_RETRIES=true` to execute each request exactly once. This is
+useful during debugging or when operating against mock services that do not
+need retry protection.

--- a/main.py
+++ b/main.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import logging
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -26,6 +26,8 @@ from exporters.excel_exporter import ExcelExporter
 from exporters.json_exporter import JSONExporter
 from processors.audit_processor import AuditProcessor
 from releasecopilot import uploader
+from releasecopilot.errors import ReleaseCopilotError
+from releasecopilot.logging_config import configure_logging, get_logger
 
 
 def _load_local_dotenv() -> None:
@@ -63,35 +65,7 @@ class AuditConfig:
     output_prefix: str = "audit_results"
 
 
-def setup_logging() -> None:
-    level = os.getenv("LOG_LEVEL", "INFO").upper()
-    handler = logging.StreamHandler()
-    handler.setFormatter(JsonFormatter())
-    root = logging.getLogger()
-    root.setLevel(level)
-    root.handlers = [handler]
-
-
-class JsonFormatter(logging.Formatter):
-    """Formats logs as JSON for CloudWatch-friendly output."""
-
-    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
-        payload = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-        for key, value in record.__dict__.items():
-            if key in {"args", "msg", "levelname", "levelno", "pathname", "filename", "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName", "created", "msecs", "relativeCreated", "thread", "threadName", "processName", "process", "message"}:
-                continue
-            payload[key] = value
-        if record.exc_info:
-            payload["exception"] = self.formatException(record.exc_info)
-        return json.dumps(payload)
-
-
-def parse_args(argv: Optional[Iterable[str]] = None) -> AuditConfig:
+def parse_args(argv: Optional[Iterable[str]] = None) -> tuple[argparse.Namespace, AuditConfig]:
     parser = argparse.ArgumentParser(description="Releasecopilot AI")
     parser.add_argument("--fix-version", required=True, help="Fix version to audit")
     parser.add_argument("--repos", nargs="*", default=[], help="Bitbucket repositories to inspect")
@@ -103,10 +77,11 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> AuditConfig:
     parser.add_argument("--s3-bucket", help="Override the default S3 bucket")
     parser.add_argument("--s3-prefix", help="Override the default S3 prefix")
     parser.add_argument("--output-prefix", default="audit_results", help="Basename for output files")
+    parser.add_argument("--log-level", default="INFO", help="Logging verbosity")
 
     args = parser.parse_args(argv)
 
-    return AuditConfig(
+    config = AuditConfig(
         fix_version=args.fix_version,
         repos=args.repos,
         branches=args.branches,
@@ -118,11 +93,11 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> AuditConfig:
         s3_prefix=args.s3_prefix,
         output_prefix=args.output_prefix,
     )
+    return args, config
 
 
 def run_audit(config: AuditConfig) -> Dict[str, Any]:
-    setup_logging()
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
 
     settings = load_settings()
     region = settings.get("aws", {}).get("region")
@@ -312,7 +287,7 @@ def upload_artifacts(
     raw_files: Iterable[Path],
     region: Optional[str],
 ) -> None:
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
     bucket = (
         config.s3_bucket
         or settings.get("aws", {}).get("s3_bucket")
@@ -403,5 +378,12 @@ def _detect_git_sha() -> Optional[str]:
 
 
 if __name__ == "__main__":
-    config = parse_args()
-    run_audit(config)
+    args, config = parse_args()
+    configure_logging(args.log_level)
+    try:
+        run_audit(config)
+    except ReleaseCopilotError as exc:
+        logger = get_logger(__name__)
+        logger.error("Audit execution failed", extra=getattr(exc, "context", {}))
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/src/releasecopilot/cli.py
+++ b/src/releasecopilot/cli.py
@@ -5,6 +5,8 @@ import argparse
 from pathlib import Path
 from typing import Iterable, Optional
 
+from releasecopilot.logging_config import configure_logging, get_logger
+
 try:  # pragma: no cover - optional dependency
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - optional dependency
@@ -72,6 +74,11 @@ def _create_parser() -> argparse.ArgumentParser:
         action="store_false",
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
     return parser
 
 
@@ -86,6 +93,9 @@ def run(argv: Optional[Iterable[str]] = None) -> dict:
     """Parse arguments and build the resulting configuration dictionary."""
 
     args = parse_args(argv)
+    configure_logging(args.log_level)
+    logger = get_logger(__name__)
+    logger.debug("CLI arguments parsed", extra={"args": {k: v for k, v in vars(args).items() if v is not None}})
     return build_config(args)
 
 

--- a/src/releasecopilot/config.py
+++ b/src/releasecopilot/config.py
@@ -160,7 +160,7 @@ def resolve_secret(name: str, cfg: Dict[str, Any]) -> str | None:
 def _extract_cli_overrides(cli_args: argparse.Namespace) -> Dict[str, Any]:
     data: Dict[str, Any] = {}
     for key, value in vars(cli_args).items():
-        if key == "config":
+        if key in {"config", "log_level"}:
             continue
         if value is None:
             continue

--- a/src/releasecopilot/errors.py
+++ b/src/releasecopilot/errors.py
@@ -1,0 +1,32 @@
+"""Application specific exception hierarchy."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class ReleaseCopilotError(RuntimeError):
+    """Base exception that carries structured context."""
+
+    def __init__(self, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.context = context or {}
+
+
+class JiraTokenRefreshError(ReleaseCopilotError):
+    """Raised when Jira token refresh fails."""
+
+
+class JiraQueryError(ReleaseCopilotError):
+    """Raised when Jira issue search fails."""
+
+
+class BitbucketRequestError(ReleaseCopilotError):
+    """Raised when Bitbucket requests fail."""
+
+
+__all__ = [
+    "ReleaseCopilotError",
+    "JiraTokenRefreshError",
+    "JiraQueryError",
+    "BitbucketRequestError",
+]

--- a/src/releasecopilot/logging_config.py
+++ b/src/releasecopilot/logging_config.py
@@ -1,0 +1,195 @@
+"""Central logging configuration for ReleaseCopilot."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import uuid
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Iterable
+
+
+_CONFIG_LOCK = threading.Lock()
+_CONFIGURED = False
+_CORRELATION_ID = os.getenv("RC_CORR_ID") or str(uuid.uuid4())
+
+_SENSITIVE_KEYS = {"token", "secret", "password", "key", "authorization"}
+_SENSITIVE_PATTERNS = tuple(value.lower() for value in _SENSITIVE_KEYS)
+
+
+def get_correlation_id() -> str:
+    """Return the run-scoped correlation identifier."""
+
+    return _CORRELATION_ID
+
+
+class _CorrelationIdFilter(logging.Filter):
+    """Inject the correlation identifier into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        if not hasattr(record, "correlation_id") or not record.correlation_id:
+            record.correlation_id = _CORRELATION_ID
+        return True
+
+
+def _contains_secret(value: str) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in _SENSITIVE_PATTERNS)
+
+
+def _redact(value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, str):
+        if _contains_secret(value):
+            return "***REDACTED***"
+        return value
+    if isinstance(value, dict):
+        return {key: _redact(value[key]) for key in value}
+    if isinstance(value, (list, tuple, set)):
+        container_type = type(value)
+        return container_type(_redact(item) for item in value)
+    return value
+
+
+class _RedactionFilter(logging.Filter):
+    """Filter that redacts sensitive information from log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        for key in list(record.__dict__.keys()):
+            if key in {"args", "msg", "message"}:
+                continue
+            if any(token in key.lower() for token in _SENSITIVE_PATTERNS):
+                record.__dict__[key] = "***REDACTED***"
+            else:
+                record.__dict__[key] = _redact(record.__dict__[key])
+
+        if isinstance(record.args, dict):
+            record.args = {key: _redact(value) for key, value in record.args.items()}
+        elif isinstance(record.args, Iterable) and not isinstance(record.args, str):
+            record.args = tuple(_redact(value) for value in record.args)
+
+        if isinstance(record.msg, str) and _contains_secret(record.msg):
+            record.msg = "***REDACTED***"
+        return True
+
+
+class _JsonFormatter(logging.Formatter):
+    """Formatter that outputs structured JSON payloads."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        payload: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "correlation_id": getattr(record, "correlation_id", _CORRELATION_ID),
+        }
+        for key, value in record.__dict__.items():
+            if key in {
+                "args",
+                "msg",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+                "message",
+            }:
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+class _StructuredFormatter(logging.Formatter):
+    """Plain-text structured formatter."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            fmt="%(asctime)sZ %(levelname)s %(name)s [corr=%(correlation_id)s] %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:  # noqa: D401, N802
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime(self.datefmt or "%Y-%m-%dT%H:%M:%S")
+
+
+def configure_logging(level_override: str | None = None) -> None:
+    """Configure the global logging system if it has not been configured."""
+
+    global _CONFIGURED
+
+    with _CONFIG_LOCK:
+        handler: logging.Handler
+        root = logging.getLogger()
+        first_configuration = not _CONFIGURED
+        if first_configuration:
+            handler = logging.StreamHandler(stream=sys.stdout)
+            use_json = os.getenv("RC_LOG_JSON", "false").lower() == "true"
+            handler.addFilter(_CorrelationIdFilter())
+            handler.addFilter(_RedactionFilter())
+            handler.setFormatter(_JsonFormatter() if use_json else _StructuredFormatter())
+            root.handlers = [handler]
+            root.propagate = False
+            _CONFIGURED = True
+
+        level: int | None = None
+        if level_override:
+            try:
+                level = getattr(logging, level_override.upper())
+            except AttributeError:
+                level = logging.INFO
+        elif first_configuration:
+            env_level = os.getenv("RC_LOG_LEVEL", "INFO").upper()
+            level = getattr(logging, env_level, logging.INFO)
+
+        if level is not None:
+            root.setLevel(level)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger instance."""
+
+    configure_logging()
+    return logging.getLogger(name)
+
+
+def parse_retry_after(value: str) -> float | None:
+    """Parse a Retry-After header value into seconds."""
+
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        try:
+            retry_dt = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if retry_dt is None:
+            return None
+        if retry_dt.tzinfo is None:
+            retry_dt = retry_dt.replace(tzinfo=timezone.utc)
+        delta = (retry_dt - datetime.now(timezone.utc)).total_seconds()
+        return max(delta, 0)
+
+
+__all__ = ["get_logger", "configure_logging", "get_correlation_id", "parse_retry_after"]

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -24,6 +24,11 @@ def test_parse_args_records_config_path(tmp_path: Path) -> None:
     assert Path(args.config) == config_path
 
 
+def test_cli_accepts_log_level() -> None:
+    args = cli.parse_args(["--log-level", "debug"])
+    assert args.log_level == "debug"
+
+
 def test_run_builds_config_from_yaml(tmp_path: Path) -> None:
     """``cli.run`` should integrate with ``build_config`` to produce a final mapping."""
 

--- a/tests/test_clients_retry.py
+++ b/tests/test_clients_retry.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+import requests
+
+from clients.bitbucket_client import BitbucketClient
+from clients.jira_client import JiraClient
+from releasecopilot.errors import BitbucketRequestError, JiraQueryError
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, json_data: dict[str, Any] | None = None, *, text: str = "", headers: dict[str, str] | None = None) -> None:
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self) -> dict[str, Any]:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+class FakeSession:
+    def __init__(self, responses: list[DummyResponse]) -> None:
+        self._responses = responses
+
+    def request(self, method: str, url: str, **_: Any) -> DummyResponse:
+        if not self._responses:
+            raise AssertionError("No more responses configured")
+        return self._responses.pop(0)
+
+
+class ZeroJitter:
+    def uniform(self, _: float, __: float) -> float:  # noqa: D401
+        return 0.0
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_handlers() -> None:
+    # Ensure each test starts from a clean logging configuration
+    from releasecopilot.logging_config import configure_logging
+
+    configure_logging("CRITICAL")
+
+
+def test_jira_fetch_retries_on_rate_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture) -> None:
+    responses = [
+        DummyResponse(
+            429,
+            text="Too many requests",
+            headers={"Retry-After": "1", "X-RateLimit-Remaining": "0"},
+        ),
+        DummyResponse(200, json_data={"issues": [], "total": 0}, headers={"X-RateLimit-Remaining": "98"}),
+    ]
+    client = JiraClient(
+        base_url="https://example.atlassian.net",
+        access_token="token",
+        token_expiry=int(time.time()) + 3600,
+        cache_dir=str(tmp_path),
+    )
+    client.session = FakeSession(responses)  # type: ignore[assignment]
+    client._random = ZeroJitter()
+    delays: list[float] = []
+    monkeypatch.setattr(JiraClient, "_sleep", lambda self, seconds: delays.append(seconds))
+
+    caplog.set_level("DEBUG")
+    issues, _ = client.fetch_issues(fix_version="1.0.0")
+
+    assert issues == []
+    assert delays and delays[0] >= 1
+    retry_logs = [record for record in caplog.records if record.levelname == "WARNING" and record.getMessage() == "Retrying after status"]
+    assert retry_logs
+    assert getattr(retry_logs[0], "status_code") == 429
+
+
+def test_jira_fetch_issues_raises_typed_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture) -> None:
+    responses = [
+        DummyResponse(500, json_data={}, text="server down")
+        for _ in range(5)
+    ]
+    client = JiraClient(
+        base_url="https://example.atlassian.net",
+        access_token="token",
+        token_expiry=int(time.time()) + 3600,
+        cache_dir=str(tmp_path),
+    )
+    client.session = FakeSession(responses)  # type: ignore[assignment]
+    client._random = ZeroJitter()
+    delays: list[float] = []
+    monkeypatch.setattr(JiraClient, "_sleep", lambda self, seconds: delays.append(seconds))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(JiraQueryError) as excinfo:
+        client.fetch_issues(fix_version="2.0.0")
+
+    assert excinfo.value.context["status_code"] == 500
+    assert "server down" in excinfo.value.context["snippet"]
+    assert len(delays) == client._MAX_ATTEMPTS - 1
+    assert any(record.getMessage() == "Jira search failed" for record in caplog.records)
+
+
+def test_bitbucket_retries_and_logs(monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture) -> None:
+    now = datetime.utcnow()
+    responses = [
+        DummyResponse(429, text="rate limit", headers={"Retry-After": "1"}),
+        DummyResponse(200, json_data={"values": [{"hash": "abc"}], "next": None}),
+    ]
+    client = BitbucketClient(workspace="workspace", cache_dir=str(tmp_path))
+    client.session = FakeSession(responses)  # type: ignore[assignment]
+    client._random = ZeroJitter()
+    delays: list[float] = []
+    monkeypatch.setattr(BitbucketClient, "_sleep", lambda self, seconds: delays.append(seconds))
+
+    caplog.set_level("DEBUG")
+    commits, _ = client.fetch_commits(
+        repositories=["repo"],
+        branches=["main"],
+        start=now - timedelta(days=1),
+        end=now,
+    )
+
+    assert commits and commits[0]["hash"] == "abc"
+    assert delays and delays[0] >= 1
+    assert any(record.getMessage() == "HTTP request" for record in caplog.records)
+    assert any(record.getMessage() == "HTTP response" and getattr(record, "repository", None) == "repo" for record in caplog.records)
+
+
+def test_bitbucket_raises_typed_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture) -> None:
+    now = datetime.utcnow()
+    responses = [DummyResponse(503, text="service unavailable") for _ in range(5)]
+    client = BitbucketClient(workspace="workspace", cache_dir=str(tmp_path))
+    client.session = FakeSession(responses)  # type: ignore[assignment]
+    client._random = ZeroJitter()
+    delays: list[float] = []
+    monkeypatch.setattr(BitbucketClient, "_sleep", lambda self, seconds: delays.append(seconds))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(BitbucketRequestError) as excinfo:
+        client.fetch_commits(
+            repositories=["repo"],
+            branches=["main"],
+            start=now - timedelta(days=1),
+            end=now,
+        )
+
+    assert excinfo.value.context["status_code"] == 503
+    assert "service unavailable" in excinfo.value.context["snippet"]
+    assert len(delays) == client._MAX_ATTEMPTS - 1
+    assert any(record.getMessage() == "Bitbucket HTTP error" for record in caplog.records)
+
+
+def test_retries_can_be_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    monkeypatch.setenv("RC_DISABLE_RETRIES", "true")
+    client = JiraClient(
+        base_url="https://example.atlassian.net",
+        access_token="token",
+        token_expiry=int(time.time()) + 3600,
+        cache_dir=str(tmp_path),
+    )
+    client.session = FakeSession([DummyResponse(500, text="error")])  # type: ignore[assignment]
+    client._random = ZeroJitter()
+    calls: list[float] = []
+    monkeypatch.setattr(JiraClient, "_sleep", lambda self, seconds: calls.append(seconds))
+
+    with pytest.raises(JiraQueryError):
+        client.fetch_issues(fix_version="no-retry")
+
+    assert not calls

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _reload_logging(monkeypatch: pytest.MonkeyPatch, **env: str) -> ModuleType:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    for name in list(sys.modules):
+        if name.startswith("releasecopilot"):
+            sys.modules.pop(name)
+    return importlib.import_module("releasecopilot.logging_config")
+
+
+def test_structured_logging_includes_correlation_id(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("RC_CORR_ID", "test-corr-id")
+    monkeypatch.delenv("RC_LOG_JSON", raising=False)
+    logging_module = _reload_logging(monkeypatch)
+    logging_module.configure_logging("INFO")
+    logger = logging_module.get_logger("test.logger")
+
+    logger.info("hello world")
+
+    output = capsys.readouterr().out.strip()
+    assert "hello world" in output
+    assert "test-corr-id" in output
+    assert output.startswith("20")
+
+
+def test_json_logging_mode(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    logging_module = _reload_logging(monkeypatch, RC_LOG_JSON="true")
+    logging_module.configure_logging("INFO")
+    logger = logging_module.get_logger("json.logger")
+
+    logger.info("structured message")
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["message"] == "structured message"
+    assert payload["correlation_id"] == logging_module.get_correlation_id()
+
+
+def test_secret_redaction(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.delenv("RC_LOG_JSON", raising=False)
+    logging_module = _reload_logging(monkeypatch)
+    logging_module.configure_logging("DEBUG")
+    logger = logging_module.get_logger("redact.logger")
+
+    logger.debug("token value", extra={"api_token": "abc123", "nested": {"secret": "shhh"}})
+
+    output = capsys.readouterr().out
+    assert "***REDACTED***" in output
+    assert "abc123" not in output
+    assert "shhh" not in output


### PR DESCRIPTION
## Summary
- add a reusable logging_config module that provides correlation IDs, JSON/text output, and secret redaction
- introduce typed errors and consistent retry/backoff handling across Jira and Bitbucket clients
- wire CLI entrypoints to the new logger, expose a --log-level flag, and document observability and retry behaviour

## Testing
- ruff check .
- pytest -q
- cd infra/cdk && cdk synth *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d455504ec0832fae9eec1262015495