### PR TITLE
Add Jira webhook sync pipeline and DynamoDB-backed store

### DIFF
--- a/clients/jira_store.py
+++ b/clients/jira_store.py
@@ -1,0 +1,168 @@
+"""DynamoDB-backed Jira issue store for release audits."""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+from releasecopilot.errors import JiraQueryError
+from releasecopilot.logging_config import get_logger
+
+
+logger = get_logger(__name__)
+
+
+_RETRYABLE_DDB_ERRORS = {
+    "ProvisionedThroughputExceededException",
+    "ThrottlingException",
+    "RequestLimitExceeded",
+    "InternalServerError",
+    "TransactionInProgressException",
+}
+
+
+def _utcnow() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class _QueryConfig:
+    index_name: str = "FixVersionIndex"
+    consistent_read: bool = False
+
+
+class JiraIssueStore:
+    """Fetch Jira issues from a DynamoDB table maintained by webhook ingestion."""
+
+    def __init__(
+        self,
+        *,
+        table_name: str,
+        region_name: Optional[str] = None,
+        query_config: _QueryConfig | None = None,
+        table_resource: Any | None = None,
+    ) -> None:
+        if not table_name:
+            raise ValueError("DynamoDB table name is required")
+        self.table_name = table_name
+        self._query_config = query_config or _QueryConfig()
+        if table_resource is None:
+            resource = boto3.resource("dynamodb", region_name=region_name)
+            table_resource = resource.Table(table_name)
+        self._table = table_resource
+        self._sleep = time.sleep
+
+    # Public API -----------------------------------------------------
+    def fetch_issues(
+        self,
+        *,
+        fix_version: str,
+        use_cache: bool = False,  # compatibility signature
+        fields: Optional[List[str]] = None,
+    ) -> tuple[List[Dict[str, Any]], Optional[str]]:
+        del use_cache, fields  # Unused but kept for interface parity
+        logger.info(
+            "Querying cached Jira issues", extra={"table": self.table_name, "fix_version": fix_version}
+        )
+        try:
+            items = list(self._paginate_query(fix_version=fix_version))
+        except ClientError as exc:
+            self._handle_ddb_error(exc, fix_version)
+        except Exception as exc:  # pragma: no cover - defensive
+            context = {"table": self.table_name, "fix_version": fix_version, "error": str(exc)}
+            logger.exception("Unexpected error querying Jira issue table", extra=context)
+            raise JiraQueryError("Failed to query Jira issue store", context=context) from exc
+
+        issues: List[Dict[str, Any]] = []
+        for item in items:
+            if item.get("deleted"):
+                continue
+            issue_payload = item.get("issue")
+            if not isinstance(issue_payload, dict):
+                logger.warning(
+                    "Skipping malformed issue item", extra={"issue_id": item.get("issue_id")}
+                )
+                continue
+            issues.append(issue_payload)
+
+        issues.sort(key=lambda issue: issue.get("key") or "")
+        logger.info(
+            "Loaded %d Jira issues from local store", len(issues), extra={"fix_version": fix_version}
+        )
+        return issues, None
+
+    # Internal helpers -----------------------------------------------
+    def _paginate_query(self, *, fix_version: str) -> Iterable[Dict[str, Any]]:
+        if not fix_version:
+            logger.warning("Empty fix version provided to JiraIssueStore; returning no items")
+            return []
+
+        params: Dict[str, Any] = {
+            "IndexName": self._query_config.index_name,
+            "KeyConditionExpression": Key("fix_version").eq(fix_version),
+            "ScanIndexForward": False,
+        }
+        if self._query_config.consistent_read:
+            params["ConsistentRead"] = True
+
+        last_key: Optional[Dict[str, Any]] = None
+        while True:
+            if last_key:
+                params["ExclusiveStartKey"] = last_key
+            response = self._execute_query(params)
+            for item in response.get("Items", []):
+                yield item
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+
+    def _execute_query(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        max_attempts = int(os.getenv("RC_DDB_MAX_ATTEMPTS", "5"))
+        base_delay = float(os.getenv("RC_DDB_BASE_DELAY", "0.5"))
+        attempt = 1
+        while True:
+            try:
+                return self._table.query(**params)
+            except ClientError as exc:
+                if not self._should_retry(exc) or attempt >= max_attempts:
+                    raise
+                delay = self._compute_delay(attempt, base_delay)
+                logger.warning(
+                    "Retrying DynamoDB query", extra={"attempt": attempt, "delay": round(delay, 2)}
+                )
+                self._sleep(delay)
+                attempt += 1
+
+    @staticmethod
+    def _compute_delay(attempt: int, base_delay: float) -> float:
+        jitter = base_delay * 0.25
+        return base_delay * (2 ** (attempt - 1)) + jitter
+
+    @staticmethod
+    def _should_retry(error: ClientError) -> bool:
+        code = (error.response.get("Error", {}) or {}).get("Code")
+        return code in _RETRYABLE_DDB_ERRORS
+
+    def _handle_ddb_error(self, error: ClientError, fix_version: str) -> None:
+        code = (error.response.get("Error", {}) or {}).get("Code")
+        message = (error.response.get("Error", {}) or {}).get("Message")
+        context = {
+            "table": self.table_name,
+            "fix_version": fix_version,
+            "code": code,
+            "error_message": message,
+            "request_id": error.response.get("ResponseMetadata", {}).get("RequestId"),
+            "captured_at": _utcnow(),
+        }
+        logger.error("DynamoDB query failed", extra=context)
+        raise JiraQueryError("Failed to query Jira issue store", context=context) from error
+
+
+__all__ = ["JiraIssueStore"]
+

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,6 +11,10 @@ jira:
   base_url: https://your-domain.atlassian.net
   cloud_id: your-cloud-id
   issue_table_name: releasecopilot-ai-jira-issues
+  reconciliation:
+    cron: cron(15 7 * * ? *)
+    jql_template: "fixVersion = '{fix_version}' ORDER BY key"
+    fix_versions: ""
 bitbucket:
   workspace: your-workspace
   default_branches:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -10,6 +10,7 @@ aws:
 jira:
   base_url: https://your-domain.atlassian.net
   cloud_id: your-cloud-id
+  issue_table_name: releasecopilot-ai-jira-issues
 bitbucket:
   workspace: your-workspace
   default_branches:

--- a/infra/cdk/app.py
+++ b/infra/cdk/app.py
@@ -47,6 +47,16 @@ def _load_context(app: App) -> Dict[str, Any]:
         "lambdaTimeoutSec": int(_context(app, "lambdaTimeoutSec", 180)),
         "lambdaMemoryMb": int(_context(app, "lambdaMemoryMb", 512)),
         "jiraWebhookSecretArn": str(_context(app, "jiraWebhookSecretArn", "")),
+        "jiraBaseUrl": str(_context(app, "jiraBaseUrl", "https://your-domain.atlassian.net")),
+        "reconciliationCron": str(_context(app, "reconciliationCron", "")),
+        "reconciliationFixVersions": str(_context(app, "reconciliationFixVersions", "")),
+        "reconciliationJqlTemplate": str(
+            _context(app, "reconciliationJqlTemplate", "fixVersion = '{fix_version}' ORDER BY key")
+        ),
+        "reconciliationScheduleEnabled": _to_bool(
+            _context(app, "reconciliationScheduleEnabled", True)
+        ),
+        "metricsNamespace": str(_context(app, "metricsNamespace", "ReleaseCopilot/JiraSync")),
     }
 
 
@@ -137,6 +147,12 @@ CoreStack(
     schedule_enabled=context["scheduleEnabled"],
     schedule_cron=context["scheduleCron"],
     jira_webhook_secret_arn=context["jiraWebhookSecretArn"] or None,
+    reconciliation_schedule_expression=context["reconciliationCron"] or None,
+    enable_reconciliation_schedule=context["reconciliationScheduleEnabled"],
+    reconciliation_fix_versions=context["reconciliationFixVersions"] or None,
+    reconciliation_jql_template=context["reconciliationJqlTemplate"] or None,
+    jira_base_url=context["jiraBaseUrl"] or None,
+    metrics_namespace=context["metricsNamespace"] or None,
 )
 
 app.synth()

--- a/infra/cdk/app.py
+++ b/infra/cdk/app.py
@@ -46,6 +46,7 @@ def _load_context(app: App) -> Dict[str, Any]:
         "lambdaHandler": str(_context(app, "lambdaHandler", "main.handler")),
         "lambdaTimeoutSec": int(_context(app, "lambdaTimeoutSec", 180)),
         "lambdaMemoryMb": int(_context(app, "lambdaMemoryMb", 512)),
+        "jiraWebhookSecretArn": str(_context(app, "jiraWebhookSecretArn", "")),
     }
 
 
@@ -135,6 +136,7 @@ CoreStack(
     lambda_memory_mb=context["lambdaMemoryMb"],
     schedule_enabled=context["scheduleEnabled"],
     schedule_cron=context["scheduleCron"],
+    jira_webhook_secret_arn=context["jiraWebhookSecretArn"] or None,
 )
 
 app.synth()

--- a/services/jira_reconciliation_job/__init__.py
+++ b/services/jira_reconciliation_job/__init__.py
@@ -1,0 +1,5 @@
+"""Nightly Jira reconciliation Lambda package."""
+
+from .handler import handler
+
+__all__ = ["handler"]

--- a/services/jira_reconciliation_job/handler.py
+++ b/services/jira_reconciliation_job/handler.py
@@ -1,0 +1,475 @@
+"""Lambda handler performing nightly reconciliation between Jira and DynamoDB."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+from urllib import error, parse, request
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO"))
+
+TABLE_NAME = os.environ["TABLE_NAME"]
+JIRA_BASE_URL = os.getenv("JIRA_BASE_URL", "https://your-domain.atlassian.net").rstrip("/")
+JQL_TEMPLATE = os.getenv("JQL_TEMPLATE", "fixVersion = '{fix_version}' ORDER BY key")
+FIX_VERSIONS_RAW = os.getenv("FIX_VERSIONS", "")
+MAX_RESULTS = int(os.getenv("MAX_RESULTS", "100"))
+JIRA_SECRET_ARN = os.getenv("JIRA_SECRET_ARN")
+METRICS_NAMESPACE = os.getenv("METRICS_NAMESPACE", "ReleaseCopilot/JiraSync")
+RC_DDB_MAX_ATTEMPTS = int(os.getenv("RC_DDB_MAX_ATTEMPTS", "5"))
+RC_DDB_BASE_DELAY = float(os.getenv("RC_DDB_BASE_DELAY", "0.5"))
+TOKEN_REFRESH_ENDPOINT = "https://auth.atlassian.com/oauth/token"
+
+
+_DDB = boto3.resource("dynamodb")
+_TABLE = _DDB.Table(TABLE_NAME)
+_SECRETS = boto3.client("secretsmanager") if JIRA_SECRET_ARN else None
+_CLOUDWATCH = boto3.client("cloudwatch")
+_SECRET_CACHE: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class JiraCredentials:
+    """Container for Jira authentication material."""
+
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    token_expiry: Optional[int] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    email: Optional[str] = None
+    api_token: Optional[str] = None
+
+    @property
+    def uses_oauth(self) -> bool:
+        return bool(self.client_id and (self.refresh_token or self.access_token))
+
+    @property
+    def uses_basic(self) -> bool:
+        return bool(self.email and self.api_token)
+
+
+class JiraSession:
+    """Minimal Jira REST session supporting OAuth refresh or basic auth."""
+
+    def __init__(self, base_url: str, credentials: JiraCredentials) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.creds = credentials
+        self.access_token = credentials.access_token
+        self.refresh_token = credentials.refresh_token
+        self.token_expiry = credentials.token_expiry or 0
+
+    def search(self, jql: str, *, fields: Optional[Sequence[str]] = None) -> List[Dict[str, Any]]:
+        headers = self._build_headers()
+        params = {
+            "jql": jql,
+            "maxResults": MAX_RESULTS,
+            "fields": ",".join(fields) if fields else "*all",
+        }
+        start_at = 0
+        issues: List[Dict[str, Any]] = []
+
+        while True:
+            params["startAt"] = start_at
+            url = f"{self.base_url}/rest/api/3/search?{parse.urlencode(params)}"
+            response = _http_request("GET", url, headers=headers)
+            payload = json.loads(response)
+            batch = payload.get("issues", [])
+            issues.extend(batch)
+            if not batch or start_at + params["maxResults"] >= payload.get("total", 0):
+                break
+            start_at += params["maxResults"]
+
+        return issues
+
+    def _build_headers(self) -> Dict[str, str]:
+        if self.creds.uses_oauth:
+            self._ensure_token()
+            if not self.access_token:
+                raise RuntimeError("Jira access token unavailable after refresh")
+            return {"Authorization": f"Bearer {self.access_token}", "Accept": "application/json"}
+
+        if self.creds.uses_basic:
+            token = base64.b64encode(f"{self.creds.email}:{self.creds.api_token}".encode()).decode()
+            return {
+                "Authorization": f"Basic {token}",
+                "Accept": "application/json",
+            }
+
+        raise RuntimeError("No Jira credentials available")
+
+    def _ensure_token(self) -> None:
+        if not self.creds.uses_oauth:
+            return
+        if not self.access_token or time.time() >= self.token_expiry - 30:
+            self._refresh_token()
+
+    def _refresh_token(self) -> None:
+        if not (self.creds.client_id and self.creds.client_secret and self.refresh_token):
+            raise RuntimeError("Jira refresh token flow is not configured")
+        payload = json.dumps(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self.creds.client_id,
+                "client_secret": self.creds.client_secret,
+                "refresh_token": self.refresh_token,
+            }
+        ).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        response = _http_request("POST", TOKEN_REFRESH_ENDPOINT, headers=headers, data=payload)
+        token_payload = json.loads(response)
+        self.access_token = token_payload.get("access_token")
+        self.refresh_token = token_payload.get("refresh_token", self.refresh_token)
+        expires_in = int(token_payload.get("expires_in", 0))
+        self.token_expiry = int(time.time()) + expires_in
+        LOGGER.info("Refreshed Jira OAuth token", extra={"expires_in": expires_in})
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:  # pragma: no cover - context unused
+    """Entrypoint for the nightly reconciliation Lambda."""
+
+    LOGGER.info("Starting Jira reconciliation", extra={"event": event})
+    stats: List[Dict[str, Any]] = []
+    errors: List[str] = []
+
+    try:
+        credentials = _load_credentials()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        LOGGER.exception("Failed to load Jira credentials")
+        return _response(500, {"ok": False, "message": str(exc)})
+
+    session = JiraSession(JIRA_BASE_URL, credentials)
+
+    fix_versions = _determine_fix_versions(event)
+    if not fix_versions:
+        LOGGER.info("No fix versions resolved for reconciliation")
+        return _response(200, {"ok": True, "stats": [], "message": "No fix versions configured"})
+
+    for fix_version in fix_versions:
+        try:
+            jql = JQL_TEMPLATE.format(fixVersion=fix_version, fix_version=fix_version)
+        except Exception as exc:
+            LOGGER.error("Failed to format JQL template", extra={"error": str(exc), "fix_version": fix_version})
+            errors.append(f"format:{fix_version}")
+            continue
+
+        try:
+            issues = session.search(jql)
+        except Exception as exc:  # pragma: no cover - network errors
+            LOGGER.exception("Jira search failed", extra={"fix_version": fix_version, "jql": jql})
+            errors.append(f"jira:{fix_version}")
+            continue
+
+        try:
+            result = _reconcile_fix_version(fix_version, issues)
+            stats.append(result)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            LOGGER.exception("Reconciliation failed", extra={"fix_version": fix_version})
+            errors.append(f"ddb:{fix_version}")
+
+    _publish_metrics(stats)
+
+    status = 200 if not errors else 207
+    return _response(status, {"ok": not errors, "stats": stats, "errors": errors})
+
+
+def _determine_fix_versions(event: Dict[str, Any]) -> List[str]:
+    if isinstance(event, dict):
+        explicit = event.get("fixVersions") or event.get("fix_versions")
+        if isinstance(explicit, (list, tuple)):
+            return [str(value) for value in explicit if str(value).strip()]
+    if FIX_VERSIONS_RAW:
+        return [part.strip() for part in FIX_VERSIONS_RAW.split(",") if part.strip()]
+    return sorted(_discover_fix_versions_from_table())
+
+
+def _discover_fix_versions_from_table() -> Iterable[str]:
+    projection = {"ProjectionExpression": "#fv", "ExpressionAttributeNames": {"#fv": "fix_version"}}
+    last_key: Optional[Dict[str, Any]] = None
+    seen: set[str] = set()
+
+    while True:
+        params = dict(projection)
+        if last_key:
+            params["ExclusiveStartKey"] = last_key
+        response = _execute_with_backoff(_TABLE.scan, params)
+        for item in response.get("Items", []):
+            value = item.get("fix_version")
+            if isinstance(value, str) and value and value not in seen:
+                seen.add(value)
+                yield value
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+
+def _reconcile_fix_version(fix_version: str, jira_issues: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    existing_items = list(_query_fix_version(fix_version))
+    existing_by_id = {item.get("issue_id"): item for item in existing_items if item.get("issue_id")}
+    seen_issue_ids: set[str] = set()
+
+    created = updated = unchanged = deleted = 0
+
+    for issue in jira_issues:
+        issue_id = str(issue.get("id") or issue.get("key"))
+        if not issue_id:
+            LOGGER.warning("Skipping Jira issue without id", extra={"fix_version": fix_version})
+            continue
+        seen_issue_ids.add(issue_id)
+        item = _build_item(issue, fix_version=fix_version)
+        stored = existing_by_id.get(issue_id)
+        if stored and stored.get("updated_at") == item.get("updated_at") and not stored.get("deleted"):
+            unchanged += 1
+            continue
+        _put_item_with_retry(item, item.get("updated_at"))
+        if stored:
+            updated += 1
+        else:
+            created += 1
+
+    for issue_id, stored in existing_by_id.items():
+        if issue_id in seen_issue_ids:
+            continue
+        if stored.get("deleted"):
+            continue
+        _mark_deleted(issue_id)
+        deleted += 1
+
+    LOGGER.info(
+        "Reconciled fix version",
+        extra={
+            "fix_version": fix_version,
+            "created_count": created,
+            "updated_count": updated,
+            "deleted_count": deleted,
+            "unchanged_count": unchanged,
+            "total_jira": len(jira_issues),
+        },
+    )
+    return {
+        "fixVersion": fix_version,
+        "fetched": len(jira_issues),
+        "created": created,
+        "updated": updated,
+        "deleted": deleted,
+        "unchanged": unchanged,
+    }
+
+
+def _build_item(issue: Dict[str, Any], *, fix_version: str) -> Dict[str, Any]:
+    fields = issue.get("fields") or {}
+    fix_versions = [fv.get("name") for fv in fields.get("fixVersions") or [] if fv.get("name")]
+    fix_version_value = fix_versions[0] if fix_versions else fix_version or "UNASSIGNED"
+    status = (fields.get("status") or {}).get("name", "UNKNOWN")
+    assignee = (fields.get("assignee") or {}).get("accountId") or (
+        (fields.get("assignee") or {}).get("displayName")
+    )
+    updated_at = _normalize_timestamp(fields.get("updated") or fields.get("created"))
+
+    return {
+        "issue_id": issue.get("id") or issue.get("key"),
+        "issue_key": issue.get("key"),
+        "project_key": (fields.get("project") or {}).get("key"),
+        "status": status,
+        "assignee": assignee or "UNASSIGNED",
+        "fix_version": fix_version_value,
+        "fix_versions": fix_versions,
+        "updated_at": updated_at,
+        "received_at": _now_iso(),
+        "issue": issue,
+        "deleted": False,
+        "last_event_type": "reconciliation",
+    }
+
+
+def _query_fix_version(fix_version: str) -> Iterable[Dict[str, Any]]:
+    params = {
+        "IndexName": "FixVersionIndex",
+        "KeyConditionExpression": Key("fix_version").eq(fix_version),
+    }
+    last_key: Optional[Dict[str, Any]] = None
+    while True:
+        query_params = dict(params)
+        if last_key:
+            query_params["ExclusiveStartKey"] = last_key
+        response = _execute_with_backoff(_TABLE.query, query_params)
+        for item in response.get("Items", []):
+            yield item
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+
+def _mark_deleted(issue_id: str) -> None:
+    params = {
+        "Key": {"issue_id": issue_id},
+        "UpdateExpression": "SET deleted = :true, last_event_type = :evt, received_at = :now",
+        "ExpressionAttributeValues": {
+            ":true": True,
+            ":evt": "reconciliation_missing",
+            ":now": _now_iso(),
+        },
+    }
+    _execute_with_backoff(_TABLE.update_item, params)
+
+
+def _put_item_with_retry(item: Dict[str, Any], updated_at: Optional[str]) -> None:
+    condition = "attribute_not_exists(issue_id)"
+    values: Dict[str, Any] = {}
+    if updated_at:
+        condition += " OR updated_at <= :updated"
+        values[":updated"] = updated_at
+    params: Dict[str, Any] = {"Item": item, "ConditionExpression": condition}
+    if values:
+        params["ExpressionAttributeValues"] = values
+    _execute_with_backoff(_TABLE.put_item, params)
+
+
+def _execute_with_backoff(action, params: Dict[str, Any]) -> Dict[str, Any]:
+    attempt = 1
+    while True:
+        try:
+            return action(**params)
+        except ClientError as exc:
+            code = (exc.response.get("Error", {}) or {}).get("Code")
+            if code == "ConditionalCheckFailedException":
+                LOGGER.info("Skipping outdated update", extra={"issue_id": params.get("Item", {}).get("issue_id")})
+                return {}
+            if code not in {
+                "ProvisionedThroughputExceededException",
+                "ThrottlingException",
+                "RequestLimitExceeded",
+                "InternalServerError",
+                "TransactionInProgressException",
+            } or attempt >= RC_DDB_MAX_ATTEMPTS:
+                raise
+            delay = RC_DDB_BASE_DELAY * (2 ** (attempt - 1))
+            LOGGER.warning("Retrying DynamoDB operation", extra={"attempt": attempt, "delay": round(delay, 2)})
+            time.sleep(delay)
+            attempt += 1
+
+
+def _load_credentials() -> JiraCredentials:
+    payload = _resolve_secret_payload()
+    return JiraCredentials(
+        access_token=_first(payload, ["JIRA_ACCESS_TOKEN", "access_token"]),
+        refresh_token=_first(payload, ["JIRA_REFRESH_TOKEN", "refresh_token"]),
+        token_expiry=_int_or_none(_first(payload, ["JIRA_TOKEN_EXPIRY", "token_expiry"])),
+        client_id=_first(payload, ["JIRA_CLIENT_ID", "client_id"]),
+        client_secret=_first(payload, ["JIRA_CLIENT_SECRET", "client_secret"]),
+        email=_first(payload, ["JIRA_EMAIL", "email", "username"]),
+        api_token=_first(payload, ["JIRA_API_TOKEN", "api_token"]),
+    )
+
+
+def _resolve_secret_payload() -> Dict[str, Any]:
+    global _SECRET_CACHE
+    if _SECRET_CACHE is not None:
+        return _SECRET_CACHE
+    if not JIRA_SECRET_ARN or _SECRETS is None:
+        return {}
+    try:
+        response = _SECRETS.get_secret_value(SecretId=JIRA_SECRET_ARN)
+    except ClientError as exc:  # pragma: no cover - defensive guard
+        LOGGER.error("Failed to load Jira secret", extra={"error": str(exc)})
+        return {}
+    secret_string = response.get("SecretString")
+    if not secret_string:
+        return {}
+    try:
+        payload = json.loads(secret_string)
+    except json.JSONDecodeError:
+        payload = {"value": secret_string}
+    _SECRET_CACHE = payload
+    return payload
+
+
+def _publish_metrics(stats: Sequence[Dict[str, Any]]) -> None:
+    if not stats:
+        return
+    metric_data: List[Dict[str, Any]] = []
+    for stat in stats:
+        fix_version = stat.get("fixVersion") or "UNKNOWN"
+        dimensions = [{"Name": "FixVersion", "Value": str(fix_version)}]
+        for metric_name in ("created", "updated", "deleted", "unchanged", "fetched"):
+            metric_data.append(
+                {
+                    "MetricName": f"Reconciliation{metric_name.title()}",
+                    "Dimensions": dimensions,
+                    "Value": float(stat.get(metric_name, 0)),
+                    "Unit": "Count",
+                }
+            )
+    try:
+        _CLOUDWATCH.put_metric_data(Namespace=METRICS_NAMESPACE, MetricData=metric_data)
+    except Exception:  # pragma: no cover - best effort only
+        LOGGER.warning("Failed to publish reconciliation metrics", exc_info=True)
+
+
+def _normalize_timestamp(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    text = str(raw)
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        except ValueError:
+            continue
+    return text
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _response(status: int, body: Dict[str, Any]) -> Dict[str, Any]:
+    return {"statusCode": status, "headers": {"Content-Type": "application/json"}, "body": json.dumps(body)}
+
+
+def _http_request(method: str, url: str, *, headers: Optional[Dict[str, str]] = None, data: Optional[bytes] = None) -> str:
+    req = request.Request(url, method=method, headers=headers or {})
+    if data is not None:
+        req.data = data
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8")
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore")
+        LOGGER.error("HTTP error", extra={"url": url, "status": exc.code, "body": body[:200]})
+        raise
+    except error.URLError as exc:
+        LOGGER.error("HTTP connection error", extra={"url": url, "error": str(exc)})
+        raise
+
+
+def _first(payload: Dict[str, Any], keys: Sequence[str]) -> Optional[str]:
+    for key in keys:
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _int_or_none(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = ["handler"]

--- a/services/jira_reconciliation_job/handler.py
+++ b/services/jira_reconciliation_job/handler.py
@@ -165,7 +165,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:  # pragma: n
 
         try:
             issues = session.search(jql)
-        except Exception as exc:  # pragma: no cover - network errors
+        except Exception:  # pragma: no cover - network errors
             LOGGER.exception("Jira search failed", extra={"fix_version": fix_version, "jql": jql})
             errors.append(f"jira:{fix_version}")
             continue
@@ -173,7 +173,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:  # pragma: n
         try:
             result = _reconcile_fix_version(fix_version, issues)
             stats.append(result)
-        except Exception as exc:  # pragma: no cover - defensive guard
+        except Exception:  # pragma: no cover - defensive guard
             LOGGER.exception("Reconciliation failed", extra={"fix_version": fix_version})
             errors.append(f"ddb:{fix_version}")
 

--- a/services/jira_sync_webhook/README.md
+++ b/services/jira_sync_webhook/README.md
@@ -1,0 +1,10 @@
+# Jira Sync Webhook Lambda
+
+This directory contains the source code for the Jira webhook ingestion Lambda. The
+AWS CDK stack packages this folder directly using `Code.from_asset`, so the
+folder **must remain committed to the repository** and accessible at
+`services/jira_sync_webhook/` when `cdk synth` runs (both locally and in CI).
+
+Any updates to the webhook handler should happen in place. If additional build
+steps become necessary (for example, dependency bundling), ensure those steps
+output to this directory or update the CDK asset path accordingly.

--- a/services/jira_sync_webhook/__init__.py
+++ b/services/jira_sync_webhook/__init__.py
@@ -1,0 +1,2 @@
+"""Jira webhook ingestion service."""
+

--- a/services/jira_sync_webhook/handler.py
+++ b/services/jira_sync_webhook/handler.py
@@ -1,0 +1,279 @@
+"""Lambda handler for ingesting Jira webhook events into DynamoDB."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO"))
+
+TABLE_NAME = os.environ["TABLE_NAME"]
+WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET")
+WEBHOOK_SECRET_ARN = os.getenv("WEBHOOK_SECRET_ARN")
+ALLOWED_EVENTS = {
+    "jira:issue_created",
+    "jira:issue_updated",
+    "jira:issue_deleted",
+}
+
+_RETRYABLE_ERRORS = {
+    "ProvisionedThroughputExceededException",
+    "ThrottlingException",
+    "RequestLimitExceeded",
+    "InternalServerError",
+    "TransactionInProgressException",
+}
+
+
+_DDB = boto3.resource("dynamodb")
+_TABLE = _DDB.Table(TABLE_NAME)
+_SECRETS = boto3.client("secretsmanager") if WEBHOOK_SECRET_ARN else None
+_SECRET_CACHE: Optional[str] = None
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:  # pragma: no cover - context unused
+    """Entrypoint for API Gateway -> Lambda invocations."""
+
+    LOGGER.debug("Received event", extra={"event": event})
+
+    method = (event.get("httpMethod") or "").upper()
+    if method != "POST":
+        return _response(405, {"message": "Method Not Allowed"})
+
+    expected_secret = _resolve_secret()
+    if expected_secret:
+        secret = _header(event, "X-Webhook-Secret")
+        if secret != expected_secret:
+            LOGGER.warning("Webhook authentication failed")
+            return _response(401, {"message": "Unauthorized"})
+
+    try:
+        payload = _parse_body(event)
+    except ValueError as exc:
+        LOGGER.warning("Malformed webhook payload: %s", exc)
+        return _response(400, {"message": "Invalid payload"})
+
+    event_type = payload.get("webhookEvent")
+    if event_type not in ALLOWED_EVENTS:
+        LOGGER.info("Ignoring unsupported webhook event", extra={"event_type": event_type})
+        return _response(202, {"ignored": True})
+
+    if event_type == "jira:issue_deleted":
+        result = _handle_delete(payload)
+    else:
+        result = _handle_upsert(payload)
+
+    status = 202 if result.get("success") else result.get("status", 500)
+    body = {"ok": result.get("success", False), **{k: v for k, v in result.items() if k != "success"}}
+    return _response(status, body)
+
+
+def _header(event: Dict[str, Any], key: str) -> Optional[str]:
+    headers = event.get("headers") or {}
+    for candidate, value in headers.items():
+        if candidate.lower() == key.lower():
+            return value
+    return None
+
+
+def _parse_body(event: Dict[str, Any]) -> Dict[str, Any]:
+    raw_body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        raw_body = base64.b64decode(raw_body)
+    if isinstance(raw_body, bytes):
+        raw_body = raw_body.decode("utf-8")
+    if not raw_body:
+        return {}
+    try:
+        return json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON") from exc
+
+
+def _resolve_secret() -> Optional[str]:
+    global _SECRET_CACHE
+    if WEBHOOK_SECRET:
+        return WEBHOOK_SECRET
+    if not WEBHOOK_SECRET_ARN or _SECRETS is None:
+        return None
+    if _SECRET_CACHE is not None:
+        return _SECRET_CACHE
+    try:
+        response = _SECRETS.get_secret_value(SecretId=WEBHOOK_SECRET_ARN)
+    except ClientError as exc:  # pragma: no cover - defensive path
+        LOGGER.error("Failed to resolve webhook secret", extra={"error": str(exc)})
+        return None
+    secret_string = response.get("SecretString") or ""
+    resolved = _extract_secret_string(secret_string)
+    _SECRET_CACHE = resolved
+    return resolved
+
+
+def _extract_secret_string(secret_string: str) -> Optional[str]:
+    if not secret_string:
+        return None
+    try:
+        data = json.loads(secret_string)
+    except json.JSONDecodeError:
+        return secret_string
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        for key in ("token", "secret", "value"):
+            if isinstance(data.get(key), str):
+                return data[key]
+        for value in data.values():
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _handle_upsert(payload: Dict[str, Any]) -> Dict[str, Any]:
+    issue = payload.get("issue") or {}
+    issue_id = issue.get("id") or issue.get("key")
+    if not issue_id:
+        LOGGER.error("Webhook payload missing issue identifier", extra={"payload": payload})
+        return {"success": False, "status": 400, "message": "Missing issue identifier"}
+
+    issue_fields = issue.get("fields") or {}
+    updated_at = _normalize_timestamp(
+        issue_fields.get("updated") or issue_fields.get("created") or payload.get("timestamp")
+    )
+    fix_versions = [fv.get("name") for fv in issue_fields.get("fixVersions") or [] if fv.get("name")]
+    primary_fix_version = fix_versions[0] if fix_versions else "UNASSIGNED"
+    status = (issue_fields.get("status") or {}).get("name", "UNKNOWN")
+    assignee = (issue_fields.get("assignee") or {}).get("accountId") or (
+        (issue_fields.get("assignee") or {}).get("displayName")
+    )
+
+    item = {
+        "issue_id": issue_id,
+        "issue_key": issue.get("key"),
+        "project_key": (issue_fields.get("project") or {}).get("key"),
+        "status": status,
+        "assignee": assignee or "UNASSIGNED",
+        "fix_version": primary_fix_version,
+        "fix_versions": fix_versions,
+        "updated_at": updated_at,
+        "received_at": _now_iso(),
+        "issue": issue,
+        "deleted": False,
+        "last_event_type": payload.get("webhookEvent"),
+    }
+
+    try:
+        _put_item_with_retry(item, updated_at)
+    except ClientError as exc:
+        LOGGER.error("Failed to persist Jira issue", extra={"issue_id": issue_id, "error": str(exc)})
+        return {"success": False, "status": 500, "message": "Failed to persist issue"}
+
+    LOGGER.info(
+        "Persisted Jira issue", extra={"issue_id": issue_id, "fix_version": primary_fix_version}
+    )
+    return {"success": True, "issue_id": issue_id}
+
+
+def _handle_delete(payload: Dict[str, Any]) -> Dict[str, Any]:
+    issue = payload.get("issue") or {}
+    issue_id = issue.get("id") or issue.get("key")
+    if not issue_id:
+        LOGGER.error("Delete webhook missing issue id", extra={"payload": payload})
+        return {"success": False, "status": 400, "message": "Missing issue identifier"}
+
+    try:
+        _delete_item_with_retry(issue_id)
+    except ClientError as exc:
+        LOGGER.error("Failed to delete Jira issue", extra={"issue_id": issue_id, "error": str(exc)})
+        return {"success": False, "status": 500, "message": "Failed to delete issue"}
+
+    LOGGER.info("Deleted Jira issue", extra={"issue_id": issue_id})
+    return {"success": True, "issue_id": issue_id, "deleted": True}
+
+
+def _put_item_with_retry(item: Dict[str, Any], updated_at: Optional[str]) -> None:
+    condition = "attribute_not_exists(issue_id)"
+    expression_values: Dict[str, Any] = {}
+    if updated_at:
+        condition += " OR updated_at <= :updated"
+        expression_values[":updated"] = updated_at
+
+    params: Dict[str, Any] = {
+        "Item": item,
+        "ConditionExpression": condition,
+    }
+    if expression_values:
+        params["ExpressionAttributeValues"] = expression_values
+
+    _execute_with_backoff(_TABLE.put_item, params)
+
+
+def _delete_item_with_retry(issue_id: str) -> None:
+    params = {"Key": {"issue_id": issue_id}}
+    _execute_with_backoff(_TABLE.delete_item, params)
+
+
+def _execute_with_backoff(action, params: Dict[str, Any]) -> None:
+    max_attempts = int(os.getenv("RC_DDB_MAX_ATTEMPTS", "5"))
+    base_delay = float(os.getenv("RC_DDB_BASE_DELAY", "0.5"))
+    attempt = 1
+    while True:
+        try:
+            action(**params)
+            return
+        except ClientError as exc:
+            code = (exc.response.get("Error", {}) or {}).get("Code")
+            if code == "ConditionalCheckFailedException":
+                issue_id = (
+                    (params.get("Item") or {}).get("issue_id")
+                    or (params.get("Key") or {}).get("issue_id")
+                )
+                LOGGER.info("Skipping outdated webhook", extra={"issue_id": issue_id})
+                return
+            if code not in _RETRYABLE_ERRORS or attempt >= max_attempts:
+                raise
+            delay = base_delay * (2 ** (attempt - 1))
+            LOGGER.warning(
+                "Retrying DynamoDB operation", extra={"attempt": attempt, "delay": round(delay, 2)}
+            )
+            time.sleep(delay)
+            attempt += 1
+
+
+def _normalize_timestamp(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    text = str(raw)
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        except ValueError:
+            continue
+    return text
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _response(status: int, body: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+__all__ = ["handler"]
+

--- a/tests/unit/test_jira_issue_store.py
+++ b/tests/unit/test_jira_issue_store.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+from botocore.exceptions import ClientError
+
+from clients.jira_store import JiraIssueStore
+
+
+class FakeTable:
+    def __init__(self, pages: List[Dict[str, Any]]) -> None:
+        self.pages = list(pages)
+        self.calls: List[Dict[str, Any]] = []
+
+    def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+        self.calls.append(kwargs)
+        if not self.pages:
+            return {"Items": []}
+        return self.pages.pop(0)
+
+
+def test_fetch_issues_returns_issue_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = FakeTable(
+        [
+            {
+                "Items": [
+                    {
+                        "issue_id": "100",
+                        "issue": {"key": "ABC-1", "fields": {"summary": "First"}},
+                        "deleted": False,
+                    },
+                    {
+                        "issue_id": "101",
+                        "issue": {"key": "ABC-2", "fields": {"summary": "Second"}},
+                        "deleted": False,
+                    },
+                ],
+                "LastEvaluatedKey": {"issue_id": "101"},
+            },
+            {
+                "Items": [
+                    {
+                        "issue_id": "102",
+                        "issue": {"key": "ABC-3", "fields": {"summary": "Third"}},
+                        "deleted": False,
+                    }
+                ]
+            },
+        ]
+    )
+
+    store = JiraIssueStore(table_name="table", table_resource=table)
+    monkeypatch.setattr(store, "_sleep", lambda *_: None)
+
+    issues, cache_path = store.fetch_issues(fix_version="2024.10.0")
+
+    assert cache_path is None
+    assert [issue["key"] for issue in issues] == ["ABC-1", "ABC-2", "ABC-3"]
+    assert table.calls[0]["IndexName"] == "FixVersionIndex"
+
+
+def test_fetch_issues_retries_on_throttle(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = ClientError(
+        error_response={
+            "Error": {"Code": "ProvisionedThroughputExceededException", "Message": "throttle"},
+            "ResponseMetadata": {"RequestId": "abc"},
+        },
+        operation_name="Query",
+    )
+
+    class FlakyTable(FakeTable):
+        def __init__(self) -> None:
+            super().__init__([{ "Items": [] }])
+            self.failures = 0
+
+        def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+            self.calls.append(kwargs)
+            if self.failures < 2:
+                self.failures += 1
+                raise error
+            return {"Items": []}
+
+    table = FlakyTable()
+    store = JiraIssueStore(table_name="table", table_resource=table)
+    sleeps: List[float] = []
+    monkeypatch.setattr(store, "_sleep", lambda delay: sleeps.append(delay))
+
+    issues, _ = store.fetch_issues(fix_version="2024.10.0")
+    assert issues == []
+    assert len(sleeps) == 2
+
+
+def test_fetch_issues_raises_on_non_retryable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = ClientError(
+        error_response={
+            "Error": {"Code": "ValidationException", "Message": "bad request"},
+            "ResponseMetadata": {"RequestId": "xyz"},
+        },
+        operation_name="Query",
+    )
+
+    class BrokenTable(FakeTable):
+        def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+            self.calls.append(kwargs)
+            raise error
+
+    store = JiraIssueStore(table_name="table", table_resource=BrokenTable([]))
+    with pytest.raises(Exception) as excinfo:
+        store.fetch_issues(fix_version="2024.10.0")
+
+    assert "Failed to query Jira issue store" in str(excinfo.value)

--- a/tests/unit/test_jira_reconciliation_handler.py
+++ b/tests/unit/test_jira_reconciliation_handler.py
@@ -1,0 +1,140 @@
+import importlib
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TABLE_NAME", "test-table")
+    monkeypatch.setenv("JIRA_BASE_URL", "https://example.atlassian.net")
+    monkeypatch.setenv("FIX_VERSIONS", "")
+    monkeypatch.setenv("JQL_TEMPLATE", "fixVersion = '{fix_version}'")
+    monkeypatch.setenv("JIRA_SECRET_ARN", "arn:aws:secretsmanager:region:acct:secret")
+    monkeypatch.setenv("METRICS_NAMESPACE", "Test/Jira")
+    monkeypatch.setenv("RC_DDB_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("RC_DDB_BASE_DELAY", "0.01")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    module = importlib.reload(importlib.import_module("services.jira_reconciliation_job.handler"))
+    monkeypatch.setitem(module.__dict__, "_SECRET_CACHE", {"JIRA_EMAIL": "user", "JIRA_API_TOKEN": "token"})
+    monkeypatch.setitem(module.__dict__, "_SECRETS", None)
+
+
+class DummyTable:
+    def __init__(self, items: List[Dict[str, Any]] | None = None) -> None:
+        self.items = items or []
+        self.last_query: List[Dict[str, Any]] = []
+        self.put_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
+        self.scan_calls = 0
+
+    def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        return {"Items": list(self.items)}
+
+    def scan(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        self.scan_calls += 1
+        return {"Items": [{"fix_version": "2024.05"}], "LastEvaluatedKey": None}
+
+    def put_item(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        self.put_calls.append(kwargs)
+        self.items.append(kwargs.get("Item", {}))
+        return {}
+
+    def update_item(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        self.update_calls.append(kwargs)
+        return {}
+
+
+class DummyCloudWatch:
+    def __init__(self) -> None:
+        self.metric_payloads: List[Dict[str, Any]] = []
+
+    def put_metric_data(self, Namespace: str, MetricData: List[Dict[str, Any]]) -> None:  # pragma: no cover
+        self.metric_payloads.append({"Namespace": Namespace, "MetricData": MetricData})
+
+
+def _install_table(monkeypatch: pytest.MonkeyPatch, table: DummyTable) -> Any:
+    module = importlib.import_module("services.jira_reconciliation_job.handler")
+    monkeypatch.setitem(module.__dict__, "_TABLE", table)
+    cw = DummyCloudWatch()
+    monkeypatch.setitem(module.__dict__, "_CLOUDWATCH", cw)
+    return module, cw
+
+
+def test_reconciliation_upserts_new_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = DummyTable()
+    module, cw = _install_table(monkeypatch, table)
+
+    def fake_http_request(method: str, url: str, headers=None, data=None) -> str:  # pragma: no cover - exercised indirectly
+        payload = {
+            "issues": [
+                {
+                    "id": "1000",
+                    "key": "ABC-1",
+                    "fields": {
+                        "updated": "2024-05-01T12:00:00.000+0000",
+                        "project": {"key": "ABC"},
+                        "status": {"name": "In Progress"},
+                        "assignee": {"displayName": "Ada"},
+                        "fixVersions": [{"name": "2024.05"}],
+                    },
+                }
+            ],
+            "total": 1,
+        }
+        return json.dumps(payload)
+
+    monkeypatch.setitem(module.__dict__, "_http_request", fake_http_request)
+
+    response = module.handler({"fixVersions": ["2024.05"]}, None)
+
+    assert response["statusCode"] == 200
+    assert table.put_calls
+    stored_item = table.put_calls[0]["Item"]
+    assert stored_item["issue_id"] == "1000"
+    assert stored_item["fix_version"] == "2024.05"
+    assert cw.metric_payloads
+
+
+def test_reconciliation_marks_missing_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = {
+        "issue_id": "1000",
+        "fix_version": "2024.05",
+        "deleted": False,
+        "updated_at": "2024-04-01T00:00:00Z",
+    }
+    table = DummyTable([existing])
+    module, _ = _install_table(monkeypatch, table)
+
+    def fake_http_request(method: str, url: str, headers=None, data=None) -> str:  # pragma: no cover - exercised indirectly
+        return json.dumps({"issues": [], "total": 0})
+
+    monkeypatch.setitem(module.__dict__, "_http_request", fake_http_request)
+
+    response = module.handler({"fixVersions": ["2024.05"]}, None)
+
+    assert response["statusCode"] == 200
+    assert table.update_calls
+    update = table.update_calls[0]
+    assert update["Key"] == {"issue_id": "1000"}
+    assert update["UpdateExpression"].startswith("SET deleted = :true")
+
+
+def test_reconciliation_discovers_fix_versions_when_not_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = DummyTable()
+    module, _ = _install_table(monkeypatch, table)
+
+    def fake_http_request(method: str, url: str, headers=None, data=None) -> str:  # pragma: no cover - exercised indirectly
+        return json.dumps({"issues": [], "total": 0})
+
+    monkeypatch.setitem(module.__dict__, "_http_request", fake_http_request)
+
+    response = module.handler({}, None)
+
+    assert response["statusCode"] == 200
+    assert table.scan_calls >= 1

--- a/tests/unit/test_jira_webhook_handler.py
+++ b/tests/unit/test_jira_webhook_handler.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import os
+import importlib
+from typing import Any, Dict, List
+
+import pytest
+
+os.environ.setdefault("TABLE_NAME", "test-table")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+webhook_handler = importlib.import_module("services.jira_sync_webhook.handler")
+
+
+class DummyTable:
+    def __init__(self) -> None:
+        self.items: List[Dict[str, Any]] = []
+        self.deleted: List[Dict[str, Any]] = []
+
+    def put_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
+        self.items.append(kwargs)
+
+    def delete_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
+        self.deleted.append(kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _patch_table(monkeypatch: pytest.MonkeyPatch) -> DummyTable:
+    table = DummyTable()
+    monkeypatch.setenv("TABLE_NAME", "test-table")
+    monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("WEBHOOK_SECRET_ARN", raising=False)
+    monkeypatch.setitem(webhook_handler.__dict__, "_TABLE", table)
+    monkeypatch.setitem(webhook_handler.__dict__, "TABLE_NAME", "test-table")
+    monkeypatch.setitem(webhook_handler.__dict__, "_SECRET_CACHE", None)
+    monkeypatch.setitem(webhook_handler.__dict__, "_SECRETS", None)
+    return table
+
+
+def _build_event(body: Dict[str, Any], headers: Dict[str, str] | None = None) -> Dict[str, Any]:
+    return {
+        "httpMethod": "POST",
+        "headers": headers or {},
+        "body": json.dumps(body),
+        "isBase64Encoded": False,
+    }
+
+
+def test_rejects_invalid_method() -> None:
+    response = webhook_handler.handler({"httpMethod": "GET"}, None)
+    assert response["statusCode"] == 405
+
+
+def test_upsert_event_persists_issue(monkeypatch: pytest.MonkeyPatch, _patch_table: DummyTable) -> None:
+    event = _build_event(
+        {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {
+                "id": "1000",
+                "key": "ABC-1",
+                "fields": {
+                    "updated": "2024-05-01T12:00:00.000+0000",
+                    "project": {"key": "ABC"},
+                    "status": {"name": "In Progress"},
+                    "assignee": {"displayName": "Ada"},
+                    "fixVersions": [{"name": "2024.05"}],
+                },
+            },
+        }
+    )
+
+    monkeypatch.setenv("TABLE_NAME", "test-table")
+    response = webhook_handler.handler(event, None)
+
+    assert response["statusCode"] == 202
+    assert _patch_table.items
+    item = _patch_table.items[0]
+    assert item["Item"]["issue_id"] == "1000"
+    assert item["Item"]["fix_version"] == "2024.05"
+
+
+def test_delete_event_removes_issue(monkeypatch: pytest.MonkeyPatch, _patch_table: DummyTable) -> None:
+    event = _build_event(
+        {
+            "webhookEvent": "jira:issue_deleted",
+            "issue": {"id": "1000", "key": "ABC-1"},
+        }
+    )
+    response = webhook_handler.handler(event, None)
+    assert response["statusCode"] == 202
+    assert _patch_table.deleted[0]["Key"] == {"issue_id": "1000"}
+
+
+def test_rejects_invalid_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WEBHOOK_SECRET", "expected")
+    monkeypatch.setitem(webhook_handler.__dict__, "WEBHOOK_SECRET", "expected")
+    event = _build_event({"webhookEvent": "jira:issue_created", "issue": {"id": "1", "key": "A"}})
+    response = webhook_handler.handler(event, None)
+    assert response["statusCode"] == 401
+
+
+def test_conditional_failure_is_ignored(monkeypatch: pytest.MonkeyPatch, _patch_table: DummyTable) -> None:
+    class FailOnceTable(DummyTable):
+        def __init__(self) -> None:
+            super().__init__()
+            self.called = False
+
+        def put_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
+            if not self.called:
+                self.called = True
+                from botocore.exceptions import ClientError
+
+                raise ClientError(
+                    error_response={"Error": {"Code": "ConditionalCheckFailedException"}},
+                    operation_name="PutItem",
+                )
+            super().put_item(**kwargs)
+
+    table = FailOnceTable()
+    monkeypatch.setitem(webhook_handler.__dict__, "_TABLE", table)
+
+    event = _build_event(
+        {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"id": "1", "key": "A", "fields": {"updated": "2024-05-01T00:00:00.000+0000"}},
+        }
+    )
+    response = webhook_handler.handler(event, None)
+    assert response["statusCode"] == 202
+


### PR DESCRIPTION
## Summary
- provision an API Gateway, webhook Lambda, and DynamoDB Jira issue table in the core CDK stack and expose their outputs
- implement a webhook Lambda that validates Jira callbacks, persists issue changes with backoff/idempotency, and resolves shared secrets from Secrets Manager
- add a DynamoDB-backed JiraIssueStore and update the audit flow to query the local cache instead of Jira, with comprehensive unit tests for the new components

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d463b52ab8832fb8279a842e781371