### PR TITLE
ci: fix weekly historian actionlint step

### DIFF
--- a/.github/workflows/weekly-history.yml
+++ b/.github/workflows/weekly-history.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   history:
     name: Generate history snapshot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
@@ -27,7 +27,12 @@ jobs:
           fetch-depth: 0
 
       - name: Lint workflow files
-        uses: rhysd/actionlint@v1
+        uses: reviewdog/action-actionlint@93dc1f9bc10856298b6cc1a3b3239cfbbb87fe4b # v1.67.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          filter_mode: nofilter
+          fail_on_error: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Releasecopilot AI automates release audits by correlating Jira stories with Bitbucket commits and exporting structured reports. The project ships with a modular Python codebase, Docker packaging, and AWS primitives for Lambda or container-based execution.
 
+> **Weekly Git Historian:** Our scheduled [`weekly-history`](.github/workflows/weekly-history.yml) workflow lints the repository's
+> GitHub Actions definitions with `actionlint` and publishes momentum snapshots every Monday at 14:00 UTC. Trigger it manually
+> from the **Actions** tab to generate an on-demand report.
+
 ## Features
 
 - Fetch Jira issues for a given fix version using OAuth 3LO tokens.

--- a/docs/git-historian.md
+++ b/docs/git-historian.md
@@ -55,9 +55,11 @@ The workflow in [`.github/workflows/weekly-history.yml`](../.github/workflows/we
 and can also be triggered manually (`workflow_dispatch`). It performs the following steps:
 
 1. Check out the repository.
-2. Run `python scripts/generate_history.py --since 7d --output docs/history`.
-3. Commit changes in `docs/history/*.md` on a branch named `auto/history-<date>`.
-4. Open a pull request summarizing the update.
+2. Lint the GitHub workflow definitions with [`reviewdog/action-actionlint`](https://github.com/reviewdog/action-actionlint)
+   pinned to commit `93dc1f9bc10856298b6cc1a3b3239cfbbb87fe4b` (release `v1.67.0`).
+3. Run `python scripts/generate_history.py --since 7d --output docs/history`.
+4. Commit changes in `docs/history/*.md` on a branch named `auto/history-<date>`.
+5. Open a pull request summarizing the update.
 
 If no files change, the workflow exits early and does not create a PR.
 
@@ -66,6 +68,21 @@ To run the workflow manually:
 1. Navigate to **Actions → Weekly Git Historian** in GitHub.
 2. Click **Run workflow** and optionally override the `since` window or template path.
 3. A pull request is created automatically if new history content is generated.
+
+### Linting and maintenance
+
+* The workflow lint step relies on `reviewdog/action-actionlint` pinned to commit
+  `93dc1f9bc10856298b6cc1a3b3239cfbbb87fe4b` (release `v1.67.0`). Update to a newer
+  version by editing the `uses:` line in the workflow to a newer commit SHA and adjusting
+  this document.
+* The action runs `actionlint` against files in `.github/workflows/`. If lint errors are
+  reported, the job fails and the check run contains the detailed findings.
+* When bumping the version, use `curl https://api.github.com/repos/reviewdog/action-actionlint/releases`
+  (or the GitHub UI) to select the desired release, copy the commit SHA, and update the
+  workflow `uses:` reference.
+* If the GitHub Actions runner cannot resolve the action due to registry outages, fall back
+  to [installing the binary directly](https://github.com/rhysd/actionlint#download) in a shell
+  step. Add a TODO comment in the workflow and revert once the marketplace issue is resolved.
 
 ## Customization
 


### PR DESCRIPTION
## Summary
- run the weekly historian workflow on ubuntu-24.04 and replace the failing `rhysd/actionlint` step with reviewdog/action-actionlint pinned to commit v1.67.0
- document the linting approach, version bump instructions, and fallback plan in `docs/git-historian.md`
- surface the weekly historian workflow in the README for quick visibility

## Testing
- /tmp/actionlint .github/workflows/weekly-history.yml

------
https://chatgpt.com/codex/tasks/task_e_68d5bef56380832fa759a399e785ed65