### PR TITLE
fix(cli): add debug scan flag for historian

### DIFF
--- a/docs/context/context-index.json
+++ b/docs/context/context-index.json
@@ -12,7 +12,20 @@
         "notes": 0,
         "artifacts": 0
       }
+    },
+    {
+      "date": "2025-09-26",
+      "file": "docs/history/2025-09-26-checkin.md",
+      "since": "2025-09-19T21:30:22.022862+00:00",
+      "until": "2025-09-26T21:30:22.022879+00:00",
+      "counts": {
+        "completed": 30,
+        "in_progress": 0,
+        "backlog": 0,
+        "notes": 0,
+        "artifacts": 33
+      }
     }
   ],
-  "generated_at": "2025-09-25T20:50:33.901648+00:00"
+  "generated_at": "2025-09-26T21:30:31.694506+00:00"
 }

--- a/docs/git-historian.md
+++ b/docs/git-historian.md
@@ -22,10 +22,12 @@ pip install -r requirements.txt
 # Generate a history snapshot from the last 7 days
 export GITHUB_TOKEN=<your-token>
 export PYTHONPATH=$(pwd)
-python -m scripts.generate_history --since 7d --until now --output docs/history
+python -m scripts.generate_history --since 7d --until now --output docs/history --debug-scan
 ```
 
 * The script creates `docs/history/YYYY-MM-DD-checkin.md` using [`docs/history/HISTORY_TEMPLATE.md`](history/HISTORY_TEMPLATE.md).
+* Use `--debug-scan` to automatically enable DEBUG logging and emit additional scan diagnostics (counts, resolved paths).
+  Pass `--log-level` if you need a different verbosity.
 * Use `--since` with ISO timestamps (`2025-01-01T00:00:00Z`) or relative windows (`14d`, `48h`).
 * Use `--until now` (default) or a specific ISO timestamp (`2025-01-15`) to cap the window end.
 * Use `--repo owner/name` to override automatic repository detection.
@@ -55,7 +57,7 @@ and can also be triggered manually (`workflow_dispatch`). It performs the follow
 2. Lint the GitHub workflow definitions with [`reviewdog/action-actionlint`](https://github.com/reviewdog/action-actionlint)
    pinned to commit `93dc1f9bc10856298b6cc1a3b3239cfbbb87fe4b` (release `v1.67.0`) and `fail_level: error`
    so any detected issues fail fast.
-3. Run `PYTHONPATH=$(pwd) python -m scripts.generate_history --since 7d --until now --output docs/history`.
+3. Run `PYTHONPATH=$(pwd) python -m scripts.generate_history --since 7d --until now --output docs/history --debug-scan`.
 4. Commit changes in `docs/history/*.md` on a branch named `auto/history-<date>`.
 5. Open a pull request summarizing the update.
 
@@ -94,7 +96,7 @@ To run the workflow manually:
 ## Troubleshooting
 
 * Ensure `GITHUB_TOKEN` is available; unauthenticated calls are heavily rate limited.
-* Use `--log-level DEBUG` for verbose output when debugging API calls.
+* Use `--debug-scan` (or `--log-level DEBUG`) for verbose output when debugging API calls or data collectors.
 * If you rely on Jira, confirm the `HISTORIAN_JIRA_*` variables are set and the JQL matches your workflow.
 * Customize the schedule in the workflow by editing the cron expression in `weekly-history.yml`.
 

--- a/docs/history/2025-09-26-checkin.md
+++ b/docs/history/2025-09-26-checkin.md
@@ -1,0 +1,90 @@
+# Weekly Check-in: 2025-09-26
+
+_Generated from history snapshot starting 2025-09-19 and ending 2025-09-26_
+
+## Completed (30)
+- PR [#129](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/129): feat: extend historian with project, notes, and artifact collectors by @dutchsloot84 (merged 2025-09-26)
+- PR [#113](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/113): chore(ci): resolve actionlint deprecation + shellcheck warnings by @dutchsloot84 (merged 2025-09-26)
+- PR [#112](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/112): chore: weekly history snapshot 2025-09-26 by @github-actions[bot] (merged 2025-09-26)
+- PR [#110](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/110): ci: configure historian token permissions by @dutchsloot84 (merged 2025-09-26)
+- PR [#111](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/111): Refine Historian Workflow Permissions and Fix Actionlint Issue by @dutchsloot84 (merged 2025-09-26)
+- PR [#108](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/108): ci: fix weekly historian actionlint step by @dutchsloot84 (merged 2025-09-26)
+- PR [#106](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/106):  Implement and Fix Weekly Git Historian Automation by @dutchsloot84 (merged 2025-09-25)
+- PR [#104](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/104): feat: add git historian automation by @dutchsloot84 (merged 2025-09-25)
+- PR [#82](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/82): Develop to Main Merge by @dutchsloot84 (merged 2025-09-25)
+- PR [#80](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/80): Add Jira webhook sync pipeline and DynamoDB-backed store by @dutchsloot84 (merged 2025-09-25)
+- PR [#79](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/79): Add structured logging, retries, and typed errors by @dutchsloot84 (merged 2025-09-24)
+- PR [#68](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/68): Develop by @dutchsloot84 (merged 2025-09-24)
+- PR [#65](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/65): Consolidate CI workflow and document updates by @dutchsloot84 (merged 2025-09-24)
+- PR [#66](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/66): Add optional EventBridge schedule for audit Lambda by @dutchsloot84 (merged 2025-09-24)
+- PR [#63](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/63): Develop by @dutchsloot84 (merged 2025-09-24)
+- PR [#62](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/62): Align CDK CI workflow with secret guardrails by @dutchsloot84 (merged 2025-09-24)
+- PR [#60](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/60): Ensure CDK CI runs core checks with step-level secret gating by @dutchsloot84 (merged 2025-09-24)
+- PR [#61](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/61): Develop by @dutchsloot84 (merged 2025-09-24)
+- PR [#58](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/58): Add CloudWatch alarms for Lambda and optional SNS notifications by @dutchsloot84 (merged 2025-09-24)
+- PR [#55](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/55): Develop by @dutchsloot84 (merged 2025-09-24)
+- PR [#57](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/57): Fix CDK synth workflow and environment resolution by @dutchsloot84 (merged 2025-09-24)
+- PR [#54](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/54): feat: add CDK core stack skeleton by @dutchsloot84 (merged 2025-09-23)
+- PR [#53](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/53): feat(cdk): codify core infra stack by @dutchsloot84 (merged 2025-09-23)
+- PR [#45](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/45): Add targeted tests and mark binary golden artifact by @dutchsloot84 (merged 2025-09-23)
+- PR [#43](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/43): Add S3 artifact uploader with AWS metadata by @dutchsloot84 (merged 2025-09-22)
+- PR [#42](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/42): Add baseline CI workflow by @dutchsloot84 (merged 2025-09-22)
+- PR [#41](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/41): Develop by @dutchsloot84 (merged 2025-09-22)
+- PR [#39](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/39): Add audit diff utilities and Streamlit compare view by @dutchsloot84 (merged 2025-09-22)
+- PR [#38](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/38): Develop by @dutchsloot84 (merged 2025-09-19)
+- PR [#37](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/37): feat(ui): add streamlit audit dashboard by @dutchsloot84 (merged 2025-09-19)
+
+## In Progress (0)
+_Filters: Project 'Release Copilot' • Status ∈ [In Progress]_
+_Scope: GitHub issues labeled in-progress_
+_No matching in-progress issues (see filters above)_
+
+## Backlog (0)
+_Filters: Project 'Release Copilot' • Status ∈ [Backlog]_
+_Scope: GitHub issues via Projects v2 board_
+_No matching backlog issues (see filters above)_
+
+## Notes & Decisions (0)
+_Markers: Decision:, Note:, Blocker:, Action:_
+_Scope: comment bodies for issues & pull requests_
+_Mirrored notes files: docs/history/notes/**/*.md_
+_No decision markers captured in this window_
+
+## Artifacts & Traceability (33)
+- Workflow `ci.yml` run [#51](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18049805095) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4119290200/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#49](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18049162406) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4119079571/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#48](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18047528432) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4118497292/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#47](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18046717604) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4118211324/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#46](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18046293211) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4118051446/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#45](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18045881755) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4117906579/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#44](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18045409853) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4117736767/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#42](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18045402358) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4117733544/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#40](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18025190975) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110829364/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#39](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18025152907) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110818624/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#38](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18025137796) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110814985/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#36](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18025077276) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110799143/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#35](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18024911053) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110754380/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#34](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18024861438) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110741179/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#33](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18024741087) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110708259/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#32](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18024687070) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110691515/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#30](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18024089752) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4110484575/zip), expires 2025-10-03)
+- Workflow `ci.yml` run [#28](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18021484215) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4109567590/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#27](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18021442189) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4109552750/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#26](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18021225324) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4109463948/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#25](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/18020454336) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4109175531/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#23](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17993949042) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4099658478/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#22](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17993908475) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4099648319/zip), expires 2025-10-02)
+- Workflow `ci.yml` run [#21](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17991668445) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4099013005/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#20](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17991382053) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4098919565/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#19](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17990946295) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4098776181/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#18](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17990577160) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4098646444/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#16](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17989312667) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4098187480/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#14](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17988527094) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4097894361/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#13](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17988463645) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4097873059/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#12](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17988353422) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4097830873/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#9](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17984990120) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4096563075/zip), expires 2025-10-01)
+- Workflow `ci.yml` run [#8](https://github.com/dutchsloot84/ReleaseCopilot-AI/actions/runs/17984444785) → **lambda_bundle** ([download](https://api.github.com/repos/dutchsloot84/ReleaseCopilot-AI/actions/artifacts/4096349004/zip), expires 2025-10-01)
+
+---
+
+<sub>Generated by Git Historian. Customize sections via scripts/generate_history.py options.</sub>

--- a/tests/test_generate_history_cli.py
+++ b/tests/test_generate_history_cli.py
@@ -1,0 +1,29 @@
+import logging
+
+from scripts import generate_history
+
+
+def test_parser_accepts_debug_scan_flag() -> None:
+    parser = generate_history._build_parser()  # type: ignore[attr-defined]
+    args = parser.parse_args(["--debug-scan"])
+
+    assert args.debug_scan is True
+    assert args.log_level is None
+
+
+def test_debug_scan_defaults_to_debug_level() -> None:
+    parser = generate_history._build_parser()  # type: ignore[attr-defined]
+    args = parser.parse_args(["--debug-scan"])
+
+    level = generate_history._determine_log_level(args)  # type: ignore[attr-defined]
+
+    assert level == logging.DEBUG
+
+
+def test_explicit_log_level_overrides_debug_scan() -> None:
+    parser = generate_history._build_parser()  # type: ignore[attr-defined]
+    args = parser.parse_args(["--debug-scan", "--log-level", "WARNING"])
+
+    level = generate_history._determine_log_level(args)  # type: ignore[attr-defined]
+
+    assert level == logging.WARNING


### PR DESCRIPTION
## Summary
- add a --debug-scan flag to the Git Historian CLI that defaults logging to DEBUG and emits additional diagnostics
- document the new flag in the Git Historian runbook and align examples with the package-style invocation
- cover the flag with unit tests to ensure parsing and log-level handling stay in sync

## Testing
- pytest tests/test_generate_history_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d704886160832fb087ed68393e75a4