### PR TITLE
docs: refresh deployment guide for unified core stack

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,32 +18,55 @@ services for integration testing. Refer to the root README for detailed steps.
 ### Local Workflow
 
 ```bash
-cd cdk
+cd infra/cdk
 pip install -r requirements.txt
 cdk synth
 cdk diff
-cdk deploy --all
+cdk deploy ReleaseCopilot-<env>-Core
 ```
 
-Enable the optional EventBridge schedule when deploying the Lambda stack:
+> **Tip:** The `<env>` context defaults to `dev`. Override it with `cdk synth -c env=staging` (or any other value) to produce a differently named stack.
+
+The unified `ReleaseCopilot-<env>-Core` stack provisions:
+
+- An artifacts S3 bucket (`ArtifactsBucket`) scoped to the account, with lifecycle
+  rules for raw and report prefixes.
+- Secrets Manager secrets for Jira, Bitbucket, and an optional webhook signing
+  secret, reused across runtimes when ARNs are not supplied via context.
+- A Python 3.11 ReleaseCopilot Lambda function plus API Gateway, DynamoDB table,
+  and reconciliation/background Lambda components.
+- CloudWatch alarms, optional EventBridge schedules, and SQS DLQ support for the
+  reconciliation workflow.
+
+Enable the optional EventBridge driven sync during deployment by passing the CDK
+context flag:
 
 ```bash
-ENABLE_EVENTBRIDGE=1 cdk deploy releasecopilot-ai-lambda
+cdk deploy ReleaseCopilot-<env>-Core -c scheduleEnabled=true
 ```
 
 ### Continuous Integration
 
-- **cdk-ci**: runs on pull requests and pushes to `main`. Synthesises and diffs
-  the stacks without deploying.
+- **CI (`cdk-synth` job)**: synthesises the CDK app on every pull request and
+  push to `main`, ensuring the stack definition remains valid.
 - **cdk-deploy**: manual `workflow_dispatch` gated by the `aws-deploy`
   environment. The workflow configures AWS credentials via OIDC and deploys the
-  stacks. Provide the `AWS_OIDC_ROLE_ARN` secret scoped to that environment.
+  core stack. Provide the `AWS_OIDC_ROLE_ARN` secret scoped to that environment.
 
 ### Runtime Settings
 
-- Artifacts bucket, secret ARN, and execution role ARNs are exported as stack
-  outputs when deploying the core stack.
-- The Lambda stack consumes `ARTIFACTS_BUCKET`, `OAUTH_SECRET_ARN`, and
-  `PROJECT_NAME` environment variables to orchestrate the audit workflow.
-- Toggle the EventBridge schedule by setting `ENABLE_EVENTBRIDGE=1` during
-  deployment; the rule is created but disabled by default.
+- Stack outputs expose the artifacts bucket name, Lambda identifiers, DynamoDB
+  table, webhook URL, and reconciliation Lambda name for downstream integration.
+- The ReleaseCopilot Lambda receives `RC_S3_BUCKET`, `RC_S3_PREFIX`, and
+  `RC_USE_AWS_SECRETS_MANAGER` environment variables and looks up Jira/Bitbucket
+  OAuth credentials from Secrets Manager.
+- The reconciliation job exports `TABLE_NAME`, `JIRA_BASE_URL`,
+  `RC_DDB_MAX_ATTEMPTS`, `RC_DDB_BASE_DELAY`, `METRICS_NAMESPACE`, and
+  `JIRA_SECRET_ARN`, with optional `FIX_VERSIONS` and `JQL_TEMPLATE` values when
+  provided via context.
+- Jira webhook processing is powered by `TABLE_NAME`, `LOG_LEVEL`, and optional
+  `WEBHOOK_SECRET_ARN` environment variables surfaced by the stack.
+- Enable or disable the EventBridge schedules via the `scheduleEnabled=true` and
+  `reconciliationScheduleEnabled=false` context flags during synth/deploy. If a
+  `scheduleCron` or `reconciliationCron` expression is provided, those override
+  the default rate expressions.


### PR DESCRIPTION
## Summary
- update deployment workflow instructions to use the infra/cdk project layout
- document the unified ReleaseCopilot-<env>-Core stack resources and context flags
- refresh CI workflow references and runtime environment variable descriptions

## Testing
- no automated tests were run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d709192f90832f86f8b66720a2deae