### PR TITLE
docs: clarify S3 upload flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Production buckets are retained by default; set `"retainBucket": false` in non-p
 - `data/<prefix>.json` – Structured audit report.
 - `data/<prefix>.xlsx` – Multi-tab Excel workbook with summary, gaps, and mapping.
 
-Artifacts are also uploaded to S3 when `--upload-s3` is supplied.
+Artifacts are automatically uploaded to Amazon S3 whenever a bucket is configured via `--s3-bucket` (or the corresponding
+configuration/env setting). Use `--s3-prefix` to control the destination prefix.
 
 ## Docker Compose
 


### PR DESCRIPTION
## Summary
- update the README outputs section to reflect the current `--s3-bucket` and `--s3-prefix` options
- align the upload wording with the CLI options table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70917f88c832f92a945c5d1f313e1