### PR TITLE
Add GitHub OIDC policy templates and CDK diff workflow

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -1,0 +1,75 @@
+name: cdk-ci
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'cdk/**'
+      - 'infra/iam/**'
+      - '.github/workflows/cdk-ci.yml'
+      - 'scripts/package_lambda.sh'
+      - 'scripts/package_lambda.py'
+  push:
+    branches:
+      - main
+    paths:
+      - 'cdk/**'
+      - 'infra/iam/**'
+      - '.github/workflows/cdk-ci.yml'
+      - 'scripts/package_lambda.sh'
+      - 'scripts/package_lambda.py'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-west-2' }}
+  PROJECT_NAME: ${{ vars.PROJECT_NAME || 'releasecopilot-ai' }}
+
+jobs:
+  diff:
+    name: CDK diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r cdk/requirements.txt
+
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk@2
+
+      - name: Package Lambda artifacts
+        run: |
+          if [ -x scripts/package_lambda.sh ]; then
+            scripts/package_lambda.sh
+          elif [ -f scripts/package_lambda.py ]; then
+            python scripts/package_lambda.py --out dist/lambda_bundle.zip
+          else
+            echo "No lambda packaging helper found" >&2
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: cdk-ci
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: CDK diff
+        env:
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+        run: |
+          cd cdk
+          cdk diff "${PROJECT_NAME}-core"
+          cdk diff "${PROJECT_NAME}-lambda"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,6 +53,13 @@ cdk deploy ReleaseCopilot-<env>-Core -c scheduleEnabled=true
   environment. The workflow configures AWS credentials via OIDC and deploys the
   core stack. Provide the `AWS_OIDC_ROLE_ARN` secret scoped to that environment.
 
+### GitHub OIDC deploy role
+
+1. In IAM create a new role with a **Web identity** trust policy. Use `infra/iam/github-actions-oidc-trust.json` as the baseline document and replace `<AWS_ACCOUNT_ID>` and the `repo:` condition with your own values.
+2. Attach a customer managed policy using `infra/iam/github-actions-oidc-permissions.json`. Replace `<AWS_REGION>`, `<AWS_ACCOUNT_ID>`, `<PROJECT_STACK_PREFIX>`, `<ARTIFACT_BUCKET_NAME>`, `<JIRA_TABLE_NAME>`, `<PROJECT_SECRET_PREFIX>`, and `<LAMBDA_LOG_GROUP_PREFIX>` with the deployed resource names (stack outputs provide the concrete values). The actions are scoped to the DynamoDB, S3, Secrets Manager, and CloudWatch Logs resources created by the CDK stacks.
+3. Save the role ARN as the `AWS_OIDC_ROLE_ARN` repository secret (or environment secret for production) so that GitHub Actions can assume it.
+4. The new `.github/workflows/cdk-ci.yml` workflow assumes this role to run `cdk diff` on pull requests that touch the CDK app. The manual `cdk-deploy` workflow continues to use the same secret for production deployments.
+
 ### Runtime Settings
 
 - Stack outputs expose the artifacts bucket name, Lambda identifiers, DynamoDB

--- a/docs/history/notes/2025-09-30-dutchsloot84-ReleaseCopilot-AI-137.md
+++ b/docs/history/notes/2025-09-30-dutchsloot84-ReleaseCopilot-AI-137.md
@@ -1,0 +1,28 @@
+# Notes & Decisions — #137 Major Historian Module Enhancements, Stability Fixes, and Documentation Updates
+
+_Repo:_ dutchsloot84/ReleaseCopilot-AI
+_Source:_ https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137
+
+- Decision (Uncategorized) — 2025-09-26 by @dutchsloot84
+  Historian will only be invoked via `python -m scripts.generate_history` with `PYTHONPATH` set; direct `python scripts/...` is deprecated.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:901c95e93fb10bd82c435274d845c465d84b302ef58fab7bc2858efb6ec9a276 -->
+
+- Decision (Uncategorized) — 2025-09-26 by @dutchsloot84
+  Notes-mirror promotes PR/Issue markers [Decision|Note|Blocker|Action] into the weekly history ledger.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:cd27699d61fa42e92dabb2043403bfa8644e33de1d2d5a2a994a3468baedef3c -->
+
+- Note (Uncategorized) — 2025-09-26 by @dutchsloot84
+  Added `--debug-scan` and guarded `--since/--until`; updated collectors/templates; Windows-compatible `until` support.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:ba05b6749ed1a1d76571e83f1190c56d29992ea94dc83f40c55cfe31aa6fc2f0 -->
+
+- Action (Uncategorized) — 2025-09-26 by @dutchsloot84
+  (Owner: Shayne) Update the weekly Historian workflow to the module invocation and ensure `permissions: { pull-requests: read, issues: read, contents: read }` before the next scheduled run.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:664fc76270832473fef3e0fca125d5f69459a4240595922447f098c4d9412324 -->
+
+- Action (Uncategorized) — 2025-09-26 by @dutchsloot84
+  (Owner: Shayne) Run a local dry run to confirm marker capture: `python -m scripts.generate_history --since 10d --until now --output docs/history --debug-scan` and check the scan log for this comment.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:69393b4c5473f73df03fcd777dcfaecfa9cbe5a06fd1523c0ca435c4f1d24bc8 -->
+
+- Blocker (Uncategorized) — 2025-09-26 by @dutchsloot84
+  If the scheduled run still uses the old entrypoint or lacks PR read permissions, marker collection will be incomplete; fix workflow invocation/permissions first.
+  [View comment](https://github.com/dutchsloot84/ReleaseCopilot-AI/pull/137#issuecomment-3340633705) <!-- digest:6e6cecd53509da2f932a9ba900291721f75e9cb1311b6fad311cf65fb9a9985b -->

--- a/infra/iam/github-actions-oidc-permissions.json
+++ b/infra/iam/github-actions-oidc-permissions.json
@@ -1,0 +1,98 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:GetTemplate",
+        "cloudformation:ValidateTemplate",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:DeleteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:ExecuteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:<AWS_REGION>:<AWS_ACCOUNT_ID>:stack/<PROJECT_STACK_PREFIX>-*/*"
+    },
+    {
+      "Sid": "ArtifactsBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:PutBucketVersioning",
+        "s3:PutEncryptionConfiguration",
+        "s3:PutLifecycleConfiguration",
+        "s3:PutBucketPolicy",
+        "s3:DeleteBucketPolicy",
+        "s3:PutBucketTagging",
+        "s3:GetBucketTagging",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketOwnershipControls",
+        "s3:GetBucketOwnershipControls",
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<ARTIFACT_BUCKET_NAME>",
+        "arn:aws:s3:::<ARTIFACT_BUCKET_NAME>/*"
+      ]
+    },
+    {
+      "Sid": "JiraDynamoTable",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:UpdateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:UpdateTimeToLive",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource"
+      ],
+      "Resource": "arn:aws:dynamodb:<AWS_REGION>:<AWS_ACCOUNT_ID>:table/<JIRA_TABLE_NAME>"
+    },
+    {
+      "Sid": "SecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:TagResource",
+        "secretsmanager:UntagResource",
+        "secretsmanager:UpdateSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:<AWS_REGION>:<AWS_ACCOUNT_ID>:secret:<PROJECT_SECRET_PREFIX>*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:DescribeLogGroups",
+        "logs:PutRetentionPolicy",
+        "logs:DeleteRetentionPolicy",
+        "logs:TagLogGroup",
+        "logs:UntagLogGroup"
+      ],
+      "Resource": "arn:aws:logs:<AWS_REGION>:<AWS_ACCOUNT_ID>:log-group:/aws/lambda/<LAMBDA_LOG_GROUP_PREFIX>*:*"
+    }
+  ]
+}

--- a/infra/iam/github-actions-oidc-trust.json
+++ b/infra/iam/github-actions-oidc-trust.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:dutchsloot84/ReleaseCopilot-AI:*"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run CDK diff with the OIDC deployment role
- provide trust and permissions policy templates for the GitHub OIDC IAM role
- document how to configure the role and reuse it across CDK workflows

## Testing
- not run (docs and workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dc1e29bd64832f94ad73d675479b4b