### PR TITLE
Normalize CDK entrypoint handling

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -95,35 +95,33 @@ jobs:
         run: bash scripts/ci/check_single_cdk_json.sh
 
       - name: Preflight — validate canonical app
+        working-directory: ${{ github.workspace }}
         run: |
           echo "PWD=$(pwd)"
-          ls -la
+          ls -la infra/cdk
 
-          if [ ! -f cdk.json ]; then
+          if [ ! -f infra/cdk/cdk.json ]; then
             echo "::error::Missing infra/cdk/cdk.json"
             exit 1
           fi
 
-          echo "cdk.json:"
-          cat cdk.json
-          APP=$(jq -r '.app // empty' cdk.json || true)
+          echo "infra/cdk/cdk.json:"
+          cat infra/cdk/cdk.json
+          APP=$(jq -r '.app // empty' infra/cdk/cdk.json || true)
           if [ -z "$APP" ] || [ "$APP" = "null" ]; then
-            echo "::error::cdk.json exists but \"app\" is empty/missing."
+            echo "::error::infra/cdk/cdk.json exists but \"app\" is empty/missing."
             exit 1
           fi
           echo "Raw app from cdk.json: $APP"
 
-          # Enforce python3 on GH runners (replace leading `python ` with `python3 `)
           if echo "$APP" | grep -qE '^python(\s|$)'; then
             APP="python3${APP#python}"
             echo "Normalized app to use python3: $APP"
           fi
 
-          # Validate that the referenced script exists
-          # Extract the first non-option arg after python3 for path check
           FIRST_ARG=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP")
           if [ -n "$FIRST_ARG" ]; then
-            if [ ! -f "$FIRST_ARG" ]; then
+            if [ ! -f "$FIRST_ARG" ] && [ ! -f "infra/cdk/$FIRST_ARG" ]; then
               echo "::error::App entry file not found: $FIRST_ARG (from app: \"$APP\")"
               exit 1
             fi
@@ -131,8 +129,11 @@ jobs:
             echo "::warning::Could not automatically detect a .py entry file from app. Ensure it exists."
           fi
 
-          # Export for subsequent steps
           echo "APP=$APP" >> $GITHUB_ENV
+
+      - name: Verify CDK entrypoint
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/ci/verify_cdk_entrypoint.sh
 
       - name: Install Python deps (CDK app)
         run: |

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "python infra/cdk/run_cdk_app.py",
+  "app": "python run_cdk_app.py",
   "context": {
     "env": "dev",
     "region": "us-west-2",

--- a/infra/cdk/infra/cdk/run_cdk_app.py
+++ b/infra/cdk/infra/cdk/run_cdk_app.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-import runpy
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-runpy.run_path(ROOT / "run_cdk_app.py", run_name="__main__")

--- a/scripts/ci/verify_cdk_entrypoint.sh
+++ b/scripts/ci/verify_cdk_entrypoint.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+CDK_JSON="$ROOT/infra/cdk/cdk.json"
+ENTRY_EXPECTED_A="python infra/cdk/run_cdk_app.py"
+ENTRY_EXPECTED_A_PY3="python3 infra/cdk/run_cdk_app.py"
+ENTRY_EXPECTED_B="python run_cdk_app.py"
+ENTRY_EXPECTED_B_PY3="python3 run_cdk_app.py"
+
+if [[ ! -f "$CDK_JSON" ]]; then
+  echo "::error::Missing infra/cdk/cdk.json"
+  exit 1
+fi
+
+APP_CMD="$(jq -r '.app // empty' "$CDK_JSON")"
+if [[ -z "$APP_CMD" || "$APP_CMD" == "null" ]]; then
+  echo "::error::The \"app\" field in infra/cdk/cdk.json is empty"
+  exit 1
+fi
+
+echo "infra/cdk/cdk.json app => $APP_CMD"
+
+mapfile -t CDK_JSONS < <(git ls-files | grep -E '(^|/)cdk.json$' || true)
+for p in "${CDK_JSONS[@]}"; do
+  if [[ "$p" != "infra/cdk/cdk.json" ]]; then
+    echo "::error::Non-canonical cdk.json files detected: $p"
+    exit 1
+  fi
+done
+
+if git ls-files | grep -q '^infra/cdk/infra/cdk/'; then
+  echo "::error::Nested infra/cdk/infra/cdk directory detected; please flatten the CDK layout."
+  exit 1
+fi
+
+ENTRY_SCRIPT=""
+case "$APP_CMD" in
+  "$ENTRY_EXPECTED_A"|"$ENTRY_EXPECTED_A_PY3")
+    ENTRY_SCRIPT="infra/cdk/run_cdk_app.py"
+    ;;
+  "$ENTRY_EXPECTED_B"|"$ENTRY_EXPECTED_B_PY3")
+    ENTRY_SCRIPT="infra/cdk/run_cdk_app.py"
+    ;;
+  python*|python3*)
+    ENTRY_SCRIPT="$(awk '{for (i=1;i<=NF;i++){if ($i ~ /\.py$/){print $i; exit}}}' <<<"$APP_CMD")"
+    ;;
+  *)
+    echo "::warning::App command does not start with python: $APP_CMD"
+    ;;
+esac
+
+if [[ -n "$ENTRY_SCRIPT" ]]; then
+  if [[ ! -f "$ROOT/$ENTRY_SCRIPT" ]]; then
+    echo "::error::App entry file not found: $ENTRY_SCRIPT"
+    exit 1
+  fi
+else
+  echo "::warning::Unable to determine entry script from app command."
+fi
+
+echo "CDK entrypoint verification passed."


### PR DESCRIPTION
## Summary
- update the CDK CI workflow preflight checks to read the canonical configuration from the repo root and surface the resolved app command
- add a guard script that enforces the single canonical CDK entrypoint and fails fast when the nested copy reappears
- align the CDK app configuration and remove the redundant nested entrypoint script

## Testing
- npx -y aws-cdk@2 list
- npx -y aws-cdk@2 synth


------
https://chatgpt.com/codex/tasks/task_e_68def0e7e294832f8eb2acbe1954b81f