### PR TITLE
Fix CDK workflow entrypoint handling

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -31,9 +31,6 @@ jobs:
   validate:
     name: Validate CDK app
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infra/cdk
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,47 +91,12 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash scripts/ci/check_single_cdk_json.sh
 
-      - name: Preflight — validate canonical app
-        run: |
-          echo "PWD=$(pwd)"
-          ls -la
-
-          if [ ! -f cdk.json ]; then
-            echo "::error::Missing infra/cdk/cdk.json"
-            exit 1
-          fi
-
-          echo "cdk.json:"
-          cat cdk.json
-          APP=$(jq -r '.app // empty' cdk.json || true)
-          if [ -z "$APP" ] || [ "$APP" = "null" ]; then
-            echo "::error::cdk.json exists but \"app\" is empty/missing."
-            exit 1
-          fi
-          echo "Raw app from cdk.json: $APP"
-
-          # Enforce python3 on GH runners (replace leading `python ` with `python3 `)
-          if echo "$APP" | grep -qE '^python(\s|$)'; then
-            APP="python3${APP#python}"
-            echo "Normalized app to use python3: $APP"
-          fi
-
-          # Validate that the referenced script exists
-          # Extract the first non-option arg after python3 for path check
-          FIRST_ARG=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP")
-          if [ -n "$FIRST_ARG" ]; then
-            if [ ! -f "$FIRST_ARG" ]; then
-              echo "::error::App entry file not found: $FIRST_ARG (from app: \"$APP\")"
-              exit 1
-            fi
-          else
-            echo "::warning::Could not automatically detect a .py entry file from app. Ensure it exists."
-          fi
-
-          # Export for subsequent steps
-          echo "APP=$APP" >> $GITHUB_ENV
+      - name: Verify CDK entrypoint
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/ci/verify_cdk_entrypoint.sh
 
       - name: Install Python deps (CDK app)
+        working-directory: infra/cdk
         run: |
           python3 -V
           if [ -f requirements.txt ]; then
@@ -147,20 +109,23 @@ jobs:
 
       - name: Install Node deps (if Node app)
         if: ${{ hashFiles('infra/cdk/package.json') != '' }}
+        working-directory: infra/cdk
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           if jq -e '.scripts.build' package.json >/dev/null 2>&1; then npm run build; fi
 
       - name: Python preflight
+        working-directory: infra/cdk
         run: |
           python3 scripts/preflight.py
           python3 run_cdk_app.py --help || true
 
       - name: CDK doctor
         run: |
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
           npx -y aws-cdk@2 cdk --version
-          npx -y aws-cdk@2 cdk doctor || true
-          cat cdk.context.json || true
+          npx -y aws-cdk@2 cdk doctor -a "$APP" "$@" || true
+          cat infra/cdk/cdk.context.json || true
 
       - name: Configure AWS credentials
         if: env.OIDC_ROLE_ARN != ''
@@ -174,22 +139,22 @@ jobs:
         if: env.OIDC_ROLE_ARN != ''
         run: aws sts get-caller-identity
 
-      - name: CDK list (verbose with fallback)
+      - name: CDK list
         run: |
           set -e
-          echo "Attempt 1: cdk -v list"
-          if ! npx -y aws-cdk@2 cdk -v list; then
-            echo "Attempt 1 failed; trying explicit -a"
-            echo "Using APP from env: $APP"
-            npx -y aws-cdk@2 cdk -v -a "$APP" list
-          fi
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
+          npx -y aws-cdk@2 cdk -v -a "$APP" "$@" list
 
       - name: CDK synth
-        run: npx -y aws-cdk@2 cdk synth
+        run: |
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
+          npx -y aws-cdk@2 cdk -a "$APP" "$@" synth
 
       - name: CDK diff
         continue-on-error: true
-        run: npx -y aws-cdk@2 cdk diff || true
+        run: |
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
+          npx -y aws-cdk@2 cdk -a "$APP" "$@" diff || true
 
       - name: Upload synthesized app
         if: always() && hashFiles('infra/cdk/cdk.out/**') != ''
@@ -205,9 +170,6 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    defaults:
-      run:
-        working-directory: infra/cdk
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -256,43 +218,12 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash scripts/ci/check_single_cdk_json.sh
 
-      - name: Preflight — validate canonical app
-        run: |
-          echo "PWD=$(pwd)"
-          ls -la
-
-          if [ ! -f cdk.json ]; then
-            echo "::error::Missing infra/cdk/cdk.json"
-            exit 1
-          fi
-
-          echo "cdk.json:"
-          cat cdk.json
-          APP=$(jq -r '.app // empty' cdk.json || true)
-          if [ -z "$APP" ] || [ "$APP" = "null" ]; then
-            echo "::error::cdk.json exists but \"app\" is empty/missing."
-            exit 1
-          fi
-          echo "Raw app from cdk.json: $APP"
-
-          if echo "$APP" | grep -qE '^python(\s|$)'; then
-            APP="python3${APP#python}"
-            echo "Normalized app to use python3: $APP"
-          fi
-
-          FIRST_ARG=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP")
-          if [ -n "$FIRST_ARG" ]; then
-            if [ ! -f "$FIRST_ARG" ]; then
-              echo "::error::App entry file not found: $FIRST_ARG (from app: \"$APP\")"
-              exit 1
-            fi
-          else
-            echo "::warning::Could not automatically detect a .py entry file from app. Ensure it exists."
-          fi
-
-          echo "APP=$APP" >> $GITHUB_ENV
+      - name: Verify CDK entrypoint
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/ci/verify_cdk_entrypoint.sh
 
       - name: Install Python deps (CDK app)
+        working-directory: infra/cdk
         run: |
           python3 -V
           if [ -f requirements.txt ]; then
@@ -305,20 +236,23 @@ jobs:
 
       - name: Install Node deps (if Node app)
         if: ${{ hashFiles('infra/cdk/package.json') != '' }}
+        working-directory: infra/cdk
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           if jq -e '.scripts.build' package.json >/dev/null 2>&1; then npm run build; fi
 
       - name: Python preflight
+        working-directory: infra/cdk
         run: |
           python3 scripts/preflight.py
           python3 run_cdk_app.py --help || true
 
       - name: CDK doctor
         run: |
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
           npx -y aws-cdk@2 cdk --version
-          npx -y aws-cdk@2 cdk doctor || true
-          cat cdk.context.json || true
+          npx -y aws-cdk@2 cdk doctor -a "$APP" "$@" || true
+          cat infra/cdk/cdk.context.json || true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -330,15 +264,13 @@ jobs:
       - name: Who am I
         run: aws sts get-caller-identity
 
-      - name: CDK list (verbose with fallback)
+      - name: CDK list
         run: |
           set -e
-          echo "Attempt 1: cdk -v list"
-          if ! npx -y aws-cdk@2 cdk -v list; then
-            echo "Attempt 1 failed; trying explicit -a"
-            echo "Using APP from env: $APP"
-            npx -y aws-cdk@2 cdk -v -a "$APP" list
-          fi
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
+          npx -y aws-cdk@2 cdk -v -a "$APP" "$@" list
 
       - name: CDK deploy all stacks
-        run: npx -y aws-cdk@2 cdk deploy --require-approval never --all
+        run: |
+          eval "set -- $CDK_CONTEXT_ARGS_SHELL"
+          npx -y aws-cdk@2 cdk -a "$APP" "$@" deploy --require-approval never --all

--- a/infra/cdk/infra/cdk/run_cdk_app.py
+++ b/infra/cdk/infra/cdk/run_cdk_app.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-import runpy
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-runpy.run_path(ROOT / "run_cdk_app.py", run_name="__main__")

--- a/scripts/ci/verify_cdk_entrypoint.sh
+++ b/scripts/ci/verify_cdk_entrypoint.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+  GITHUB_ENV="$(mktemp)"
+fi
+
+CDK_JSON="infra/cdk/cdk.json"
+ENTRY_EXPECTED="infra/cdk/run_cdk_app.py"
+
+if [[ ! -f "$CDK_JSON" ]]; then
+  echo "::error::Missing canonical cdk.json at $CDK_JSON" >&2
+  exit 1
+fi
+
+mapfile -t CDK_JSONS < <(git ls-files | grep -E '(^|/)cdk.json$' || true)
+for path in "${CDK_JSONS[@]}"; do
+  if [[ "$path" != "$CDK_JSON" ]]; then
+    echo "::error::Non-canonical cdk.json detected at: $path" >&2
+    exit 1
+  fi
+done
+
+if [[ -d "infra/cdk/infra/cdk" ]]; then
+  echo "::error::Nested infra/cdk/infra/cdk directory detected; please keep CDK app files flat under infra/cdk/" >&2
+  exit 1
+fi
+
+APP_CMD=$(python3 - "$CDK_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open() as fh:
+    data = json.load(fh)
+app = data.get("app")
+if not isinstance(app, str) or not app.strip():
+    print("::error::cdk.json missing non-empty \"app\" string", file=sys.stderr)
+    sys.exit(1)
+print(app.strip())
+PY
+)
+
+APP_CMD=$(echo "$APP_CMD" | tr -d '\r')
+APP_NORMALIZED="$APP_CMD"
+if [[ "$APP_NORMALIZED" =~ ^python([[:space:]]|$) ]]; then
+  APP_NORMALIZED="python3${APP_NORMALIZED#python}"
+fi
+
+ENTRY_PATH=$(python3 - <<'PY' "$APP_CMD"
+import shlex
+import sys
+
+parts = shlex.split(sys.argv[1])
+for token in parts[1:]:
+    if token.endswith('.py'):
+        print(token)
+        break
+else:
+    print('')
+PY
+)
+
+ENTRY_PATH=$(echo "$ENTRY_PATH" | tr -d '\r')
+if [[ -z "$ENTRY_PATH" ]]; then
+  echo "::error::Unable to detect Python entry file from app command: $APP_CMD" >&2
+  exit 1
+fi
+
+if [[ "$ENTRY_PATH" != "$ENTRY_EXPECTED" ]]; then
+  echo "::error::App entry path must be $ENTRY_EXPECTED but was $ENTRY_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENTRY_PATH" ]]; then
+  echo "::error::App entry file not found: $ENTRY_PATH" >&2
+  exit 1
+fi
+
+CDK_CONTEXT_ARGS_SHELL=$(python3 - "$CDK_JSON" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open() as fh:
+    data = json.load(fh)
+context = data.get("context", {})
+if not isinstance(context, dict):
+    context = {}
+parts = []
+for key, value in context.items():
+    parts.append('-c')
+    parts.append(f"{key}={value}")
+print(" ".join(shlex.quote(part) for part in parts))
+PY
+)
+
+{
+  echo "APP=$APP_NORMALIZED"
+  echo "CDK_APP_CANONICAL=$APP_CMD"
+  echo "CDK_ENTRY_FILE=$ENTRY_PATH"
+  echo "CDK_CONTEXT_ARGS_SHELL=$CDK_CONTEXT_ARGS_SHELL"
+} >> "$GITHUB_ENV"
+
+echo "cdk.json app => $APP_CMD"
+echo "Normalized CLI app => $APP_NORMALIZED"
+echo "Entry file verified at $ENTRY_PATH"
+if [[ -n "$CDK_CONTEXT_ARGS_SHELL" ]]; then
+  echo "Context arguments => $CDK_CONTEXT_ARGS_SHELL"
+else
+  echo "Context arguments => <none>"
+fi
+
+echo "CDK entrypoint verification passed."


### PR DESCRIPTION
## Summary
- remove the nested infra/cdk/infra directory that shadowed the canonical CDK app entrypoint
- add a reusable CI guard (`scripts/ci/verify_cdk_entrypoint.sh`) that enforces the repo-root friendly app command and context resolution
- update the CDK CI workflow to run CDK commands from the repository root using the normalized app/context arguments

## Testing
- bash scripts/ci/verify_cdk_entrypoint.sh
- npx -y aws-cdk@2 list -a "python3 infra/cdk/run_cdk_app.py" -c env=dev -c region=us-west-2 -c bucketBase=releasecopilot-artifacts -c lambdaAssetPath=../../dist -c lambdaHandler=main.handler -c jiraSecretArn= -c bitbucketSecretArn= -c scheduleEnabled=False -c "scheduleCron=cron(30 1 * * ? *)" -c alarmEmail= *(fails: Cannot find asset at /dist)*

------
https://chatgpt.com/codex/tasks/task_e_68def0e7e294832f8eb2acbe1954b81f