### PR TITLE
Normalize CDK app entrypoint path

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -31,9 +31,6 @@ jobs:
   validate:
     name: Validate CDK app
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infra/cdk
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,46 +92,21 @@ jobs:
         run: bash scripts/ci/check_single_cdk_json.sh
 
       - name: Preflight — validate canonical app
+        working-directory: ${{ github.workspace }}
         run: |
-          echo "PWD=$(pwd)"
-          ls -la
-
-          if [ ! -f cdk.json ]; then
-            echo "::error::Missing infra/cdk/cdk.json"
-            exit 1
-          fi
-
-          echo "cdk.json:"
-          cat cdk.json
-          APP=$(jq -r '.app // empty' cdk.json || true)
+          bash scripts/ci/verify_cdk_entrypoint.sh
+          APP=$(jq -r '.app // empty' infra/cdk/cdk.json || true)
           if [ -z "$APP" ] || [ "$APP" = "null" ]; then
             echo "::error::cdk.json exists but \"app\" is empty/missing."
             exit 1
           fi
-          echo "Raw app from cdk.json: $APP"
-
-          # Enforce python3 on GH runners (replace leading `python ` with `python3 `)
           if echo "$APP" | grep -qE '^python(\s|$)'; then
             APP="python3${APP#python}"
-            echo "Normalized app to use python3: $APP"
           fi
-
-          # Validate that the referenced script exists
-          # Extract the first non-option arg after python3 for path check
-          FIRST_ARG=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP")
-          if [ -n "$FIRST_ARG" ]; then
-            if [ ! -f "$FIRST_ARG" ]; then
-              echo "::error::App entry file not found: $FIRST_ARG (from app: \"$APP\")"
-              exit 1
-            fi
-          else
-            echo "::warning::Could not automatically detect a .py entry file from app. Ensure it exists."
-          fi
-
-          # Export for subsequent steps
           echo "APP=$APP" >> $GITHUB_ENV
 
       - name: Install Python deps (CDK app)
+        working-directory: infra/cdk
         run: |
           python3 -V
           if [ -f requirements.txt ]; then
@@ -147,20 +119,23 @@ jobs:
 
       - name: Install Node deps (if Node app)
         if: ${{ hashFiles('infra/cdk/package.json') != '' }}
+        working-directory: infra/cdk
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           if jq -e '.scripts.build' package.json >/dev/null 2>&1; then npm run build; fi
 
       - name: Python preflight
+        working-directory: infra/cdk
         run: |
           python3 scripts/preflight.py
           python3 run_cdk_app.py --help || true
 
       - name: CDK doctor
+        working-directory: ${{ github.workspace }}
         run: |
           npx -y aws-cdk@2 cdk --version
           npx -y aws-cdk@2 cdk doctor || true
-          cat cdk.context.json || true
+          cat infra/cdk/cdk.context.json || true
 
       - name: Configure AWS credentials
         if: env.OIDC_ROLE_ARN != ''
@@ -174,25 +149,25 @@ jobs:
         if: env.OIDC_ROLE_ARN != ''
         run: aws sts get-caller-identity
 
-      - name: CDK list (verbose with fallback)
+      - name: CDK list (verbose)
+        working-directory: ${{ github.workspace }}
         run: |
           set -e
-          echo "Attempt 1: cdk -v list"
-          if ! npx -y aws-cdk@2 cdk -v list; then
-            echo "Attempt 1 failed; trying explicit -a"
-            echo "Using APP from env: $APP"
-            npx -y aws-cdk@2 cdk -v -a "$APP" list
-          fi
+          echo "Using APP from env: $APP"
+          npx -y aws-cdk@2 cdk -v -a "$APP" --output infra/cdk/cdk.out list
 
       - name: CDK synth
-        run: npx -y aws-cdk@2 cdk synth
+        working-directory: ${{ github.workspace }}
+        run: npx -y aws-cdk@2 cdk -a "$APP" --output infra/cdk/cdk.out synth
 
       - name: CDK diff
+        working-directory: ${{ github.workspace }}
         continue-on-error: true
-        run: npx -y aws-cdk@2 cdk diff || true
+        run: npx -y aws-cdk@2 cdk -a "$APP" --output infra/cdk/cdk.out diff || true
 
       - name: Upload synthesized app
         if: always() && hashFiles('infra/cdk/cdk.out/**') != ''
+        working-directory: ${{ github.workspace }}
         uses: actions/upload-artifact@v4
         with:
           name: cdk.out
@@ -205,9 +180,6 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    defaults:
-      run:
-        working-directory: infra/cdk
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -257,42 +229,21 @@ jobs:
         run: bash scripts/ci/check_single_cdk_json.sh
 
       - name: Preflight — validate canonical app
+        working-directory: ${{ github.workspace }}
         run: |
-          echo "PWD=$(pwd)"
-          ls -la
-
-          if [ ! -f cdk.json ]; then
-            echo "::error::Missing infra/cdk/cdk.json"
-            exit 1
-          fi
-
-          echo "cdk.json:"
-          cat cdk.json
-          APP=$(jq -r '.app // empty' cdk.json || true)
+          bash scripts/ci/verify_cdk_entrypoint.sh
+          APP=$(jq -r '.app // empty' infra/cdk/cdk.json || true)
           if [ -z "$APP" ] || [ "$APP" = "null" ]; then
             echo "::error::cdk.json exists but \"app\" is empty/missing."
             exit 1
           fi
-          echo "Raw app from cdk.json: $APP"
-
           if echo "$APP" | grep -qE '^python(\s|$)'; then
             APP="python3${APP#python}"
-            echo "Normalized app to use python3: $APP"
           fi
-
-          FIRST_ARG=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP")
-          if [ -n "$FIRST_ARG" ]; then
-            if [ ! -f "$FIRST_ARG" ]; then
-              echo "::error::App entry file not found: $FIRST_ARG (from app: \"$APP\")"
-              exit 1
-            fi
-          else
-            echo "::warning::Could not automatically detect a .py entry file from app. Ensure it exists."
-          fi
-
           echo "APP=$APP" >> $GITHUB_ENV
 
       - name: Install Python deps (CDK app)
+        working-directory: infra/cdk
         run: |
           python3 -V
           if [ -f requirements.txt ]; then
@@ -305,20 +256,23 @@ jobs:
 
       - name: Install Node deps (if Node app)
         if: ${{ hashFiles('infra/cdk/package.json') != '' }}
+        working-directory: infra/cdk
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           if jq -e '.scripts.build' package.json >/dev/null 2>&1; then npm run build; fi
 
       - name: Python preflight
+        working-directory: infra/cdk
         run: |
           python3 scripts/preflight.py
           python3 run_cdk_app.py --help || true
 
       - name: CDK doctor
+        working-directory: ${{ github.workspace }}
         run: |
           npx -y aws-cdk@2 cdk --version
           npx -y aws-cdk@2 cdk doctor || true
-          cat cdk.context.json || true
+          cat infra/cdk/cdk.context.json || true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -330,15 +284,13 @@ jobs:
       - name: Who am I
         run: aws sts get-caller-identity
 
-      - name: CDK list (verbose with fallback)
+      - name: CDK list (verbose)
+        working-directory: ${{ github.workspace }}
         run: |
           set -e
-          echo "Attempt 1: cdk -v list"
-          if ! npx -y aws-cdk@2 cdk -v list; then
-            echo "Attempt 1 failed; trying explicit -a"
-            echo "Using APP from env: $APP"
-            npx -y aws-cdk@2 cdk -v -a "$APP" list
-          fi
+          echo "Using APP from env: $APP"
+          npx -y aws-cdk@2 cdk -v -a "$APP" --output infra/cdk/cdk.out list
 
       - name: CDK deploy all stacks
-        run: npx -y aws-cdk@2 cdk deploy --require-approval never --all
+        working-directory: ${{ github.workspace }}
+        run: npx -y aws-cdk@2 cdk -a "$APP" --output infra/cdk/cdk.out deploy --require-approval never --all

--- a/infra/cdk/app.py
+++ b/infra/cdk/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from aws_cdk import App, Environment
@@ -123,7 +124,7 @@ def _resolve_environment(app: App, context: Dict[str, Any]) -> Tuple[Optional[st
     return account, region
 
 
-app = App()
+app = App(outdir=str(Path(__file__).resolve().parent / "cdk.out"))
 context = _load_context(app)
 
 account_id, region = _resolve_environment(app, context)

--- a/infra/cdk/infra/cdk/run_cdk_app.py
+++ b/infra/cdk/infra/cdk/run_cdk_app.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-import runpy
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-runpy.run_path(ROOT / "run_cdk_app.py", run_name="__main__")

--- a/infra/cdk/run_cdk_app.py
+++ b/infra/cdk/run_cdk_app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 def main() -> None:
     app_path = Path(__file__).resolve().parent / "app.py"
+    os.chdir(app_path.parent)
     argv = [sys.executable, str(app_path), *sys.argv[1:]]
     os.execv(sys.executable, argv)
 

--- a/scripts/ci/verify_cdk_entrypoint.sh
+++ b/scripts/ci/verify_cdk_entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+CDK_JSON="$ROOT/infra/cdk/cdk.json"
+ENTRY_EXPECTED="python infra/cdk/run_cdk_app.py"
+
+if [[ ! -f "$CDK_JSON" ]]; then
+  echo "::error::Missing canonical cdk.json at infra/cdk/cdk.json"
+  exit 1
+fi
+
+APP_CMD="$(jq -r '.app // empty' "$CDK_JSON")"
+if [[ -z "$APP_CMD" || "$APP_CMD" == "null" ]]; then
+  echo "::error::cdk.json \"app\" field is empty"
+  exit 1
+fi
+
+echo "cdk.json app => $APP_CMD"
+
+# Validate duplicates
+MAPFILE_DUPES=$(git ls-files | grep -E '(^|/)cdk.json$' | grep -v '^infra/cdk/cdk.json' || true)
+if [[ -n "$MAPFILE_DUPES" ]]; then
+  echo "::error::Non-canonical cdk.json files detected:" >&2
+  echo "$MAPFILE_DUPES" >&2
+  exit 1
+fi
+
+# Ensure nested infra/cdk/infra/cdk is absent
+if git ls-files | grep -q '^infra/cdk/infra/cdk/'; then
+  echo "::error::Nested infra/cdk/infra/cdk directory detected"
+  exit 1
+fi
+
+ENTRY_PATH="$ROOT/infra/cdk/run_cdk_app.py"
+if [[ ! -f "$ENTRY_PATH" ]]; then
+  echo "::error::Missing entry script at infra/cdk/run_cdk_app.py"
+  exit 1
+fi
+
+if [[ "$APP_CMD" != "$ENTRY_EXPECTED" ]]; then
+  echo "::warning::cdk.json app command is \"$APP_CMD\" (expected \"$ENTRY_EXPECTED\")."
+  # Attempt to verify the referenced python script exists
+  TARGET=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<< "$APP_CMD")
+  if [[ -n "$TARGET" ]]; then
+    if [[ ! -f "$ROOT/$TARGET" ]]; then
+      echo "::error::App entry file not found at $TARGET"
+      exit 1
+    fi
+  else
+    echo "::warning::Unable to detect python script path from app command"
+  fi
+fi
+
+echo "CDK entrypoint verification passed."


### PR DESCRIPTION
## Summary
- add a CI preflight script to enforce the canonical CDK app path and remove the stray nested entrypoint
- update the CDK workflows to run from the repository root while exporting the app command and output directory explicitly
- adjust the Python entrypoint to chdir before exec and pin the app outdir so relative assets resolve from the canonical infra/cdk folder

## Testing
- npx aws-cdk@2 list -a "python infra/cdk/run_cdk_app.py" --output infra/cdk/cdk.out
- npx aws-cdk@2 synth -a "python infra/cdk/run_cdk_app.py" --output infra/cdk/cdk.out


------
https://chatgpt.com/codex/tasks/task_e_68def0e7e294832f8eb2acbe1954b81f