### PR TITLE
Normalize CDK entrypoint handling

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -94,6 +94,10 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash scripts/ci/check_single_cdk_json.sh
 
+      - name: Verify CDK entrypoint
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/ci/verify_cdk_entrypoint.sh
+
       - name: Preflight — validate canonical app
         run: |
           echo "PWD=$(pwd)"

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "python infra/cdk/run_cdk_app.py",
+  "app": "python run_cdk_app.py",
   "context": {
     "env": "dev",
     "region": "us-west-2",

--- a/infra/cdk/infra/cdk/run_cdk_app.py
+++ b/infra/cdk/infra/cdk/run_cdk_app.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-import runpy
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-runpy.run_path(ROOT / "run_cdk_app.py", run_name="__main__")

--- a/scripts/ci/verify_cdk_entrypoint.sh
+++ b/scripts/ci/verify_cdk_entrypoint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+CDK_JSON="$ROOT/infra/cdk/cdk.json"
+ENTRY_EXPECTED_A="python infra/cdk/run_cdk_app.py"
+ENTRY_EXPECTED_B="python run_cdk_app.py"
+
+if [[ ! -f "$CDK_JSON" ]]; then
+  echo "::error::Missing infra/cdk/cdk.json"
+  exit 1
+fi
+
+APP_CMD="$(jq -r '.app // empty' "$CDK_JSON")"
+if [[ -z "$APP_CMD" || "$APP_CMD" == "null" ]]; then
+  echo "::error::\"app\" field missing in $CDK_JSON"
+  exit 1
+fi
+
+echo "cdk.json app => $APP_CMD"
+
+DUPS=$(git ls-files | grep -E '(^|/)cdk.json$' | grep -v '^infra/cdk/cdk.json$' || true)
+if [[ -n "$DUPS" ]]; then
+  echo "::error::Non-canonical cdk.json files detected:"
+  echo "$DUPS"
+  exit 1
+fi
+
+if [[ -d "$ROOT/infra/cdk/infra" ]] || git ls-files | grep -q '^infra/cdk/infra/'; then
+  echo "::error::Nested infra/cdk/infra directory detected; please flatten to infra/cdk/."
+  exit 1
+fi
+
+check_entry() {
+  local target="$1"
+  if [[ ! -f "$ROOT/$target" ]]; then
+    echo "::error::Entry script not found at $target"
+    exit 1
+  fi
+}
+
+if [[ "$APP_CMD" == "$ENTRY_EXPECTED_A" || "$APP_CMD" == "$ENTRY_EXPECTED_B" ]]; then
+  check_entry "infra/cdk/run_cdk_app.py"
+else
+  ENTRY=$(awk '{for(i=1;i<=NF;i++){if($i ~ /\.py$/){print $i; exit}}}' <<<"$APP_CMD")
+  if [[ -n "$ENTRY" ]]; then
+    check_entry "$ENTRY"
+  else
+    echo "::warning::Unable to determine Python entry script from app command."
+  fi
+fi
+
+echo "CDK entrypoint verification passed."


### PR DESCRIPTION
## Summary
- point the CDK app definition at the canonical run_cdk_app.py in infra/cdk
- drop the redundant nested infra/cdk/infra copy of the entrypoint
- add a CI guard that validates the CDK entrypoint configuration before running workflows

## Testing
- npx -y aws-cdk@2 list
- npx -y aws-cdk@2 synth


------
https://chatgpt.com/codex/tasks/task_e_68def0e7e294832f8eb2acbe1954b81f