### PR TITLE
chore(ci): run CDK workflows on Node 20.x

### DIFF
--- a/.github/workflows/cdk-ci.yml
+++ b/.github/workflows/cdk-ci.yml
@@ -35,7 +35,10 @@ jobs:
       - name: Setup Node (20.x)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.x'
+
+      - name: Verify Node.js runtime
+        run: node --version
 
       - name: Setup Python (3.11)
         uses: actions/setup-python@v5
@@ -50,7 +53,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install -r infra/cdk/requirements.txt
-          npm install -g aws-cdk
+          npm install -g aws-cdk@2
 
       - name: Diagnose working dir & cdk.json
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.x'
+
+      - name: Verify Node.js runtime
+        run: node --version
 
       - name: Install AWS CDK
         run: npm install -g aws-cdk@2

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -12,4 +12,6 @@ npm run cdk:diff
 npm run cdk:deploy
 ```
 
-These commands rely on CDK's default auto-discovery, so no additional `-a` flags or wrapper scripts are required. Run `npm run cdk:venv` whenever dependencies change to refresh the virtual environment. Ensure Python 3.11 and Node.js 20 are installed locally so the CLI matches the GitHub Actions environment.
+These commands rely on CDK's default auto-discovery, so no additional `-a` flags or wrapper scripts are required. Run `npm run cdk:venv` whenever dependencies change to refresh the virtual environment.
+
+> **Runtime requirement:** Install Python 3.11 and Node.js 20 LTS (20.x) locally so the CLI matches the GitHub Actions runners. After switching Node versions with tools like `nvm`, `fnm`, or Volta, confirm the runtime with `node --version`—the output should start with `v20`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "releasecopilot-ai",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": ">=20 <25",
+    "npm": ">=9"
+  },
   "scripts": {
     "cdk:venv": "python -m venv .venv && . .venv/bin/activate && python -m pip install -U pip && pip install -r infra/cdk/requirements.txt",
     "cdk:list": "npx --yes cdk list",


### PR DESCRIPTION
## Summary
- upgrade CDK GitHub Actions jobs to pin Node.js 20.x and log the active runtime
- pin the global aws-cdk CLI install to v2 and enforce Node 20+ locally via package.json engines
- document the Node.js 20 LTS requirement for developers running CDK commands

## Testing
- npm run cdk:list
- npm run cdk:synth
- npm run cdk:diff *(fails: missing AWS credentials in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e051d935d0832fb8f72c9e27d093f2