### PR TITLE
Add offline rc audit CLI and defaults loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,52 +78,45 @@ For non-local deployments, rely on AWS Secrets Manager wherever possible and onl
 
 ## CLI Usage
 
-Run the audit locally:
+Release Copilot ships with a subcommand-based CLI. The primary workflow is the
+offline audit pipeline which consumes cached Jira and Bitbucket payloads and
+regenerates the export artifacts without performing any live API calls.
+
+Generate artifacts from cached inputs:
 
 ```bash
-python main.py \
-  --fix-version 2025.09.20 \
-  --repos policycenter claimcenter \
-  --develop-only \
-  --s3-bucket my-artifacts-bucket \
-  --s3-prefix audits
+rc audit \
+  --cache-dir temp_data \
+  --json dist/audit.json \
+  --xlsx dist/audit.xlsx \
+  --scope fixVersion=2025.09.20
 ```
 
-### Available Options
+The command above reads the cached JSON payloads stored in `temp_data/`, writes
+the regenerated JSON and Excel artifacts to `dist/`, and annotates the execution
+scope with the selected fix version.
+
+### Available options
 
 | Flag | Description |
 | ---- | ----------- |
-| `--fix-version` | Release fix version (required). |
-| `--repos` | One or more Bitbucket repository slugs to inspect. |
-| `--branches` | Optional list of branches (defaults to config). |
-| `--develop-only` | Convenience flag equivalent to `--branches develop`. |
-| `--freeze-date` | ISO date representing the code freeze (default: today). |
-| `--window-days` | Days of history to analyze before the freeze date (default: 28). |
-| `--use-cache` | Reuse the latest cached API payloads instead of calling APIs. |
-| `--s3-bucket` | Override the S3 bucket defined in `config/settings.yaml`. |
-| `--s3-prefix` | Prefix within the S3 bucket for uploaded artifacts (default: `releasecopilot`). |
-| `--output-prefix` | Basename for generated output files. |
+| `--cache-dir` | Directory containing cached payloads (default: `temp_data/`). |
+| `--json` | Destination path for the JSON artifact (default: `dist/audit.json`). |
+| `--xlsx` | Destination path for the Excel artifact (default: `dist/audit.xlsx`). |
+| `--summary` | Destination path for the summary JSON (default: `dist/audit-summary.json`). |
+| `--scope` | Repeatable key-value metadata entries (for example `--scope fixVersion=2025.09.20`). |
+| `--upload` | Optional S3 URI (`s3://bucket/prefix`) that receives the generated artifacts. |
+| `--region` | AWS region for uploads (defaults to `AWS_REGION`/`AWS_DEFAULT_REGION`). |
+| `--dry-run` | Print the execution plan without touching the filesystem. |
 | `--log-level` | Logging verbosity for the current run. |
 
-### S3 Upload Layout
+### S3 uploads
 
-When an S3 bucket is configured via CLI, configuration, or environment variables,
-the audit automatically uploads generated artifacts after a successful run. The
-files are grouped by fix version and execution timestamp using the pattern:
-
-```
-s3://<bucket>/<prefix>/<fix-version>/<YYYY-MM-DD_HHMMSS>/
-├── reports/
-│   ├── <output-prefix>.json
-│   ├── <output-prefix>.xlsx
-│   └── summary.json
-└── raw/
-    ├── jira_issues.json
-    └── bitbucket_commits.json
-```
-
-Each object is encrypted with SSE-S3 and tagged with metadata that captures the
-fix version, generation timestamp, and the current Git SHA when available.
+Supplying `--upload s3://bucket/prefix` stages the generated artifacts and
+publishes them to Amazon S3 using server-side encryption. Metadata attached to
+each object includes the serialized scope payload (for Historian traceability)
+and the `rc-audit` artifact marker, enabling downstream automation to identify
+the upload.
 
 ## Streamlit Dashboard
 

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -1,0 +1,145 @@
+"""ReleaseCopilot CLI dispatcher for subcommands such as ``rc audit``."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from releasecopilot.logging_config import configure_logging, get_logger
+
+from ..config.loader import Defaults, load_defaults
+from .audit import AuditInputError, AuditOptions, AuditResult, run_audit
+
+LOGGER = get_logger(__name__)
+
+
+def _scope_entry(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"Scope values must follow key=value format (received {value!r})"
+        )
+    key, parsed = value.split("=", 1)
+    return key.strip(), parsed.strip()
+
+
+def _build_audit_parser(subparsers: argparse._SubParsersAction, defaults: Defaults) -> None:
+    audit = subparsers.add_parser(
+        "audit",
+        help="Generate release audit artifacts from cached payloads",
+    )
+    audit.add_argument(
+        "--cache-dir",
+        default=str(defaults.cache_dir),
+        help="Directory containing cached Jira/Bitbucket payloads",
+    )
+    audit.add_argument(
+        "--json",
+        default=str((defaults.artifact_dir / "audit.json")),
+        help="Path where the JSON artifact will be written",
+    )
+    audit.add_argument(
+        "--xlsx",
+        default=str((defaults.artifact_dir / "audit.xlsx")),
+        help="Path where the Excel artifact will be written",
+    )
+    audit.add_argument(
+        "--summary",
+        default=str((defaults.artifact_dir / "audit-summary.json")),
+        help="Path where the summary JSON should be stored",
+    )
+    audit.add_argument(
+        "--scope",
+        action="append",
+        default=[],
+        type=_scope_entry,
+        help="Key=value metadata entries describing the audit scope",
+    )
+    audit.add_argument(
+        "--upload",
+        help="Optional S3 destination (e.g. s3://bucket/prefix)",
+    )
+    audit.add_argument(
+        "--region",
+        help="AWS region for uploads (defaults to AWS_REGION/AWS_DEFAULT_REGION)",
+    )
+    audit.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the execution plan without reading caches or writing files",
+    )
+    audit.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
+
+
+def build_parser(defaults: Defaults | None = None) -> argparse.ArgumentParser:
+    defaults = defaults or load_defaults()
+    parser = argparse.ArgumentParser(prog="rc", description="ReleaseCopilot CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _build_audit_parser(subparsers, defaults)
+    return parser
+
+
+def _collect_audit_options(args: argparse.Namespace, defaults: Defaults) -> AuditOptions:
+    scope: dict[str, str] = {}
+    for key, value in args.scope:
+        scope[key] = value
+    region = args.region or _default_region()
+    return AuditOptions(
+        cache_dir=Path(args.cache_dir),
+        json_path=Path(args.json),
+        excel_path=Path(args.xlsx),
+        summary_path=Path(args.summary),
+        scope=scope,
+        upload_uri=args.upload,
+        region=region,
+        dry_run=args.dry_run,
+        defaults=defaults,
+    )
+
+
+def _default_region() -> str | None:
+    for key in ("AWS_REGION", "AWS_DEFAULT_REGION"):
+        value = os.environ.get(key)
+        if value:
+            return value
+    return None
+
+
+def main(argv: Iterable[str] | None = None, *, defaults: Defaults | None = None) -> int:
+    defaults = defaults or load_defaults()
+    parser = build_parser(defaults)
+    args = parser.parse_args(argv)
+
+    configure_logging(args.log_level)
+    LOGGER.debug("Parsed arguments", extra={"command": args.command})
+
+    if args.command != "audit":
+        parser.print_help()
+        return 1
+
+    options = _collect_audit_options(args, defaults)
+
+    try:
+        if args.dry_run:
+            plan = options.build_plan()
+            print(json.dumps({"plan": plan}, indent=2))
+            return 0
+
+        result: AuditResult = run_audit(options)
+    except AuditInputError as exc:
+        LOGGER.error("Audit command failed", extra={"error": str(exc)})
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(result.as_dict(), indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/cli/audit.py
+++ b/src/cli/audit.py
@@ -1,0 +1,176 @@
+"""Offline audit orchestration for the ``rc audit`` command."""
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from releasecopilot.logging_config import get_logger
+from releasecopilot.uploader import upload_directory
+
+from ..config.loader import Defaults
+from ..export.exporter import build_export_payload, export_all
+
+LOGGER = get_logger(__name__)
+
+REQUIRED_CACHE_FILES = {
+    "stories": "stories.json",
+    "commits": "commits.json",
+    "links": "links.json",
+    "summary": "summary.json",
+}
+
+
+class AuditInputError(RuntimeError):
+    """Raised when expected cached payloads are missing or invalid."""
+
+
+@dataclass(frozen=True)
+class AuditOptions:
+    cache_dir: Path
+    json_path: Path
+    excel_path: Path
+    summary_path: Path
+    scope: Mapping[str, str]
+    upload_uri: str | None
+    region: str | None
+    dry_run: bool
+    defaults: Defaults
+
+    def build_plan(self) -> Dict[str, Any]:
+        upload = None
+        if self.upload_uri:
+            bucket, prefix = parse_s3_uri(self.upload_uri)
+            upload = {
+                "bucket": bucket,
+                "prefix": prefix,
+                "region": self.region,
+            }
+        return {
+            "cache_dir": str(self.cache_dir),
+            "outputs": {
+                "json": str(self.json_path),
+                "excel": str(self.excel_path),
+                "summary": str(self.summary_path),
+            },
+            "scope": dict(self.scope),
+            "upload": upload,
+            "defaults": self.defaults.as_dict(),
+        }
+
+
+@dataclass
+class AuditResult:
+    plan: Dict[str, Any]
+    outputs: Dict[str, Path]
+    uploaded: bool
+
+    def as_dict(self) -> Dict[str, Any]:
+        data = {
+            "plan": self.plan,
+            "outputs": {name: str(path) for name, path in self.outputs.items()},
+            "uploaded": self.uploaded,
+        }
+        return data
+
+
+def parse_s3_uri(value: str) -> tuple[str, str]:
+    if not value.startswith("s3://"):
+        raise AuditInputError("S3 destinations must use the s3://bucket/prefix format")
+    remainder = value[5:]
+    if not remainder:
+        raise AuditInputError("S3 URI is missing a bucket name")
+    parts = remainder.split("/", 1)
+    bucket = parts[0]
+    prefix = parts[1] if len(parts) > 1 else ""
+    return bucket, prefix
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise AuditInputError(f"Required cache file not found: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle) or {}
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise AuditInputError(f"Cache file {path} is not valid JSON") from exc
+
+
+def load_cached_payloads(cache_dir: Path) -> Dict[str, Dict[str, Any]]:
+    cache_dir = cache_dir.resolve()
+    payloads: Dict[str, Dict[str, Any]] = {}
+    for key, filename in REQUIRED_CACHE_FILES.items():
+        path = cache_dir / filename
+        payload = _load_json(path)
+        payloads[key] = payload
+        LOGGER.debug("Loaded cached payload", extra={"key": key, "path": str(path)})
+    return payloads
+
+
+def _build_export_payload(payloads: Mapping[str, Mapping[str, Any]]) -> Dict[str, Any]:
+    return build_export_payload(
+        data={
+            "summary": payloads.get("summary", {}),
+            "stories_with_no_commits": payloads.get("stories", {}).get(
+                "stories_with_no_commits", []
+            ),
+            "orphan_commits": payloads.get("commits", {}).get("orphan_commits", []),
+            "commit_story_mapping": payloads.get("links", {}).get("commit_story_mapping", []),
+        }
+    )
+
+
+def run_audit(options: AuditOptions) -> AuditResult:
+    plan = options.build_plan()
+    LOGGER.info("Starting offline audit", extra={"cache_dir": plan["cache_dir"], "scope": plan["scope"]})
+
+    payloads = load_cached_payloads(options.cache_dir)
+    payload = _build_export_payload(payloads)
+
+    filenames = {
+        "json": options.json_path,
+        "excel": options.excel_path,
+        "summary": options.summary_path,
+    }
+    outputs = export_all(payload, out_dir=None, formats=options.defaults.export_formats, filenames=filenames)
+
+    uploaded = False
+    if options.upload_uri:
+        bucket, prefix = parse_s3_uri(options.upload_uri)
+        metadata = {
+            "scope": json.dumps(plan["scope"], sort_keys=True),
+            "artifact": "rc-audit",
+        }
+        with tempfile.TemporaryDirectory() as staging_dir:
+            staging_path = Path(staging_dir)
+            for _, path in outputs.items():
+                destination = staging_path / path.name
+                destination.write_bytes(path.read_bytes())
+            upload_directory(
+                bucket=bucket,
+                prefix=prefix,
+                local_dir=staging_path,
+                subdir="audit",
+                region_name=options.region,
+                metadata=metadata,
+            )
+        uploaded = True
+        LOGGER.info(
+            "Uploaded audit artifacts",
+            extra={"bucket": bucket, "prefix": prefix, "region": options.region},
+        )
+
+    LOGGER.info("Offline audit completed", extra={"outputs": {k: str(v) for k, v in outputs.items()}})
+    return AuditResult(plan=plan, outputs=outputs, uploaded=uploaded)
+
+
+__all__ = [
+    "AuditInputError",
+    "AuditOptions",
+    "AuditResult",
+    "load_cached_payloads",
+    "parse_s3_uri",
+    "run_audit",
+]

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -1,32 +1,95 @@
-"""Simplified configuration loader for tests and CLI helpers."""
+"""Shared configuration helpers used across the CLI and Lambda entry points."""
 from __future__ import annotations
 
 import json
+import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import yaml
+
+__all__ = ["Defaults", "load_defaults", "load_config"]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SETTINGS_PATH = REPO_ROOT / "config" / "settings.yaml"
 
 
+@dataclass(frozen=True)
+class Defaults:
+    """Container for common filesystem defaults used by the CLI and Lambda."""
+
+    project_root: Path
+    cache_dir: Path
+    artifact_dir: Path
+    reports_dir: Path
+    settings_path: Path
+    export_formats: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, str]:
+        """Return a serialisable mapping of default paths for introspection."""
+
+        return {
+            "project_root": str(self.project_root),
+            "cache_dir": str(self.cache_dir),
+            "artifact_dir": str(self.artifact_dir),
+            "reports_dir": str(self.reports_dir),
+            "settings_path": str(self.settings_path),
+            "export_formats": ",".join(self.export_formats),
+        }
+
+
+def _env(env: Mapping[str, str], key: str, default: str) -> str:
+    value = env.get(key)
+    return value if value else default
+
+
 def _load_settings_file(path: Path) -> Dict[str, Any]:
     if not path.exists():
         return {}
-    if path.suffix.lower() in {".yaml", ".yml"}:
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
         with path.open("r", encoding="utf-8") as handle:
             return yaml.safe_load(handle) or {}
-    if path.suffix.lower() == ".json":
+    if suffix == ".json":
         return json.loads(path.read_text(encoding="utf-8"))
     raise ValueError(f"Unsupported configuration format: {path}")
 
 
 def load_config(path: Optional[str | Path] = None) -> Dict[str, Any]:
-    """Load configuration from ``path`` or fall back to the default YAML settings."""
+    """Load configuration data from ``path`` or the default settings file."""
 
     target = Path(path) if path is not None else DEFAULT_SETTINGS_PATH
     return _load_settings_file(target)
 
 
-__all__ = ["load_config"]
+def load_defaults(env: Mapping[str, str] | None = None) -> Defaults:
+    """Compute default directories and configuration paths.
+
+    Environment overrides allow hosted environments (for example Lambda) to
+    tailor directory layouts without modifying the CLI logic. Every path is
+    resolved to an absolute location to avoid surprises with relative working
+    directories.
+    """
+
+    env = env or os.environ
+    project_root = Path(_env(env, "RC_ROOT", str(Path(__file__).resolve().parents[2]))).resolve()
+    cache_dir = Path(_env(env, "RC_CACHE_DIR", str(project_root / "temp_data"))).resolve()
+    artifact_dir = Path(_env(env, "RC_ARTIFACT_DIR", str(project_root / "dist"))).resolve()
+    reports_dir = Path(_env(env, "RC_REPORTS_DIR", str(project_root / "reports"))).resolve()
+    settings_path = Path(_env(env, "RC_SETTINGS_FILE", str(project_root / "config" / "settings.yaml"))).resolve()
+    export_formats = tuple(
+        fmt.strip()
+        for fmt in _env(env, "RC_EXPORT_FORMATS", "json,excel").split(",")
+        if fmt.strip()
+    )
+    if not export_formats:
+        export_formats = ("json", "excel")
+    return Defaults(
+        project_root=project_root,
+        cache_dir=cache_dir,
+        artifact_dir=artifact_dir,
+        reports_dir=reports_dir,
+        settings_path=settings_path,
+        export_formats=export_formats,
+    )

--- a/tests/cli/test_rc_audit.py
+++ b/tests/cli/test_rc_audit.py
@@ -1,0 +1,50 @@
+"""Unit tests for the ``rc audit`` CLI entry point."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.cli import app
+from src.config.loader import load_defaults
+
+
+@pytest.fixture(name="defaults")
+def _defaults_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    project_root = tmp_path
+    cache_dir = project_root / "cache"
+    cache_dir.mkdir()
+    artifact_dir = project_root / "dist"
+    reports_dir = project_root / "reports"
+    env = {
+        "RC_ROOT": str(project_root),
+        "RC_CACHE_DIR": str(cache_dir),
+        "RC_ARTIFACT_DIR": str(artifact_dir),
+        "RC_REPORTS_DIR": str(reports_dir),
+        "RC_SETTINGS_FILE": str(project_root / "config" / "settings.yaml"),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return load_defaults(env)
+
+
+def test_dry_run_outputs_plan(defaults, capsys):
+    exit_code = app.main(["audit", "--dry-run"], defaults=defaults)
+    assert exit_code == 0
+
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+    plan = payload["plan"]
+
+    assert plan["cache_dir"] == str(defaults.cache_dir)
+    assert plan["outputs"]["json"].endswith("audit.json")
+    assert plan["scope"] == {}
+
+
+def test_invalid_scope_entry_reports_error(defaults, capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        app.main(["audit", "--scope", "invalid"], defaults=defaults)
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "key=value" in stderr

--- a/tests/cli/test_rc_audit_pipeline.py
+++ b/tests/cli/test_rc_audit_pipeline.py
@@ -1,0 +1,94 @@
+"""End-to-end tests for the offline ``rc audit`` pipeline."""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.cli.audit import AuditInputError, AuditOptions, run_audit
+from src.config.loader import load_defaults
+
+
+@pytest.fixture(name="defaults")
+def _defaults(tmp_path: Path) -> tuple:
+    project_root = tmp_path
+    cache_dir = project_root / "cache"
+    artifact_dir = project_root / "dist"
+    reports_dir = project_root / "reports"
+    env = {
+        "RC_ROOT": str(project_root),
+        "RC_CACHE_DIR": str(cache_dir),
+        "RC_ARTIFACT_DIR": str(artifact_dir),
+        "RC_REPORTS_DIR": str(reports_dir),
+        "RC_SETTINGS_FILE": str(project_root / "config" / "settings.yaml"),
+    }
+    defaults = load_defaults(env)
+    return defaults, env
+
+
+def _copy_fixture_cache(src_dir: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for path in src_dir.iterdir():
+        shutil.copy2(path, dest_dir / path.name)
+
+
+def test_run_audit_generates_expected_artifacts(defaults, fixtures_dir):
+    defaults_obj, env = defaults
+    cache_dir = Path(env["RC_CACHE_DIR"])
+    _copy_fixture_cache(fixtures_dir / "temp_data", cache_dir)
+
+    json_path = Path(env["RC_ARTIFACT_DIR"]) / "audit.json"
+    excel_path = Path(env["RC_ARTIFACT_DIR"]) / "audit.xlsx"
+    summary_path = Path(env["RC_ARTIFACT_DIR"]) / "audit-summary.json"
+
+    options = AuditOptions(
+        cache_dir=cache_dir,
+        json_path=json_path,
+        excel_path=excel_path,
+        summary_path=summary_path,
+        scope={"fixVersion": "Oct25"},
+        upload_uri=None,
+        region=None,
+        dry_run=False,
+        defaults=defaults_obj,
+    )
+
+    result = run_audit(options)
+
+    assert json_path.exists()
+    assert excel_path.exists()
+    assert summary_path.exists()
+
+    golden_dir = Path(__file__).resolve().parents[1] / "fixtures" / "golden"
+    generated_payload = json.loads(json_path.read_text(encoding="utf-8"))
+    golden_payload = json.loads((golden_dir / "audit_results.json").read_text(encoding="utf-8"))
+    assert generated_payload == golden_payload
+
+    generated_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    golden_summary = json.loads((golden_dir / "summary.json").read_text(encoding="utf-8"))
+    assert generated_summary == golden_summary
+
+    assert result.uploaded is False
+    assert result.plan["scope"] == {"fixVersion": "Oct25"}
+
+
+def test_run_audit_errors_when_cache_missing(defaults):
+    defaults_obj, env = defaults
+    cache_dir = Path(env["RC_CACHE_DIR"])
+
+    options = AuditOptions(
+        cache_dir=cache_dir,
+        json_path=Path(env["RC_ARTIFACT_DIR"]) / "audit.json",
+        excel_path=Path(env["RC_ARTIFACT_DIR"]) / "audit.xlsx",
+        summary_path=Path(env["RC_ARTIFACT_DIR"]) / "audit-summary.json",
+        scope={},
+        upload_uri=None,
+        region=None,
+        dry_run=False,
+        defaults=defaults_obj,
+    )
+
+    with pytest.raises(AuditInputError):
+        run_audit(options)


### PR DESCRIPTION
## Summary
- add a subcommand-based `rc audit` CLI that rebuilds artifacts from cached payloads and supports dry-run planning and S3 uploads
- extend the shared configuration loader and exporter helpers to expose default directories and accept explicit output paths
- refresh CLI documentation and add regression tests that cover the offline pipeline end-to-end

## Testing
- pytest tests/unit/test_config.py tests/cli/test_rc_audit.py tests/cli/test_rc_audit_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e13a1ab7e8832f838fbb116f0ab746