### PR TITLE
feat(ops): add rc health readiness command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ scope with the selected fix version.
 | `--dry-run` | Print the execution plan without touching the filesystem. |
 | `--log-level` | Logging verbosity for the current run. |
 
+### Readiness smoke check
+
+Operations teams can verify AWS connectivity without running a full audit by
+invoking the readiness probe:
+
+```bash
+rc health --readiness --json dist/health.json
+```
+
+The command loads the same defaults as the audit workflow and validates
+Secrets Manager access, DynamoDB write/delete permissions, S3 object lifecycle,
+and webhook secret resolution. The JSON output follows
+[`docs/schemas/health.v1.json`](docs/schemas/health.v1.json) and is documented
+in [`docs/runbooks/health_smoke.md`](docs/runbooks/health_smoke.md).
+
 ### S3 uploads
 
 Supplying `--upload s3://bucket/prefix` stages the generated artifacts and

--- a/docs/examples/health/health-pass.v1.json
+++ b/docs/examples/health/health-pass.v1.json
@@ -1,0 +1,23 @@
+{
+  "version": "health.v1",
+  "timestamp": "2024-05-01T12:00:00Z",
+  "overall": "pass",
+  "checks": {
+    "secrets": {
+      "status": "pass",
+      "resource": "secretsmanager://jira=secret/jira, webhook=secret/webhook"
+    },
+    "dynamodb": {
+      "status": "pass",
+      "resource": "dynamodb://releasecopilot-jira-cache"
+    },
+    "s3": {
+      "status": "pass",
+      "resource": "s3://releasecopilot-artifacts/readiness/health/readiness/abc123.txt"
+    },
+    "webhook_secret": {
+      "status": "pass",
+      "resource": "secretsmanager://secret/webhook"
+    }
+  }
+}

--- a/docs/runbooks/health_smoke.md
+++ b/docs/runbooks/health_smoke.md
@@ -1,0 +1,97 @@
+# ReleaseCopilot Readiness Smoke
+
+This runbook documents the lightweight readiness probe exposed by `rc health --readiness`. The
+command validates AWS Secrets Manager access, DynamoDB connectivity, webhook secret resolution, and
+S3 write/delete permissions. The output is deterministic JSON suitable for CI gates and Historian
+artifacts.
+
+## When to Run
+
+- Before deploying webhook ingest, reconciliation, or audit jobs to a new AWS account.
+- As a CI smoke check in release pipelines.
+- On-demand when rotating secrets or modifying IAM policies.
+
+## Invocation
+
+```bash
+rc health --readiness --json dist/health.json
+```
+
+Optional flags:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--bucket s3://bucket/prefix` | Override the bucket/prefix used for the S3 sentinel object. |
+| `--table TABLE` | Override the DynamoDB table checked for write/delete access. |
+| `--secrets name1,name2` | Restrict the secret identifiers to validate. Names are looked up from `config/settings.yaml`; unknown entries are treated as literal ARNs. |
+| `--dry-run` | Show the execution plan without calling AWS services. |
+| `--json PATH` | Write readiness output to `PATH` instead of stdout. |
+| `--config PATH` | Override the settings file used for defaults. |
+| `--log-level LEVEL` | Adjust logging verbosity (defaults to `INFO`). |
+
+### Sample Output
+
+```json
+{
+  "version": "health.v1",
+  "timestamp": "2024-05-01T12:00:00Z",
+  "overall": "pass",
+  "checks": {
+    "secrets": {
+      "status": "pass",
+      "resource": "secretsmanager://jira=secret/jira, webhook=secret/webhook"
+    },
+    "dynamodb": {
+      "status": "pass",
+      "resource": "dynamodb://releasecopilot-jira-cache"
+    },
+    "s3": {
+      "status": "pass",
+      "resource": "s3://releasecopilot-artifacts/readiness/health/readiness/abc123.txt"
+    },
+    "webhook_secret": {
+      "status": "pass",
+      "resource": "secretsmanager://secret/webhook"
+    }
+  }
+}
+```
+
+## JSON Contract
+
+The output conforms to [`docs/schemas/health.v1.json`](../schemas/health.v1.json). The schema is
+validated in CI to prevent breaking changes. Consumers should pin to `version == "health.v1"`.
+
+## CI Integration
+
+```yaml
+- name: Readiness Smoke
+  run: |
+    rc health --readiness --json dist/health.json
+```
+
+Upload `dist/health.json` with the rest of the release artifacts so Historian can attach the
+readiness verdict to each deployment.
+
+## IAM Requirements
+
+| Service | Actions | Scope |
+| ------- | ------- | ----- |
+| Secrets Manager | `secretsmanager:GetSecretValue` | Specific release secrets (e.g. `arn:aws:secretsmanager:REGION:ACCOUNT:secret:releasecopilot/*`) |
+| DynamoDB | `DescribeTable`, `PutItem`, `DeleteItem` | ReleaseCopilot Jira cache table (e.g. `arn:aws:dynamodb:REGION:ACCOUNT:table/releasecopilot-jira-cache`) |
+| S3 | `PutObject`, `DeleteObject` | Artifact bucket/prefix (e.g. `arn:aws:s3:::releasecopilot-artifacts/readiness/*`) |
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Verification | Fix |
+| ------- | ------------ | ------------ | --- |
+| Secrets check fails | Missing IAM permission or incorrect ARN | Re-run with `--dry-run` and inspect `secrets` list. | Grant `secretsmanager:GetSecretValue` on the ARN or correct the value in `config/settings.yaml`. |
+| DynamoDB check fails | Wrong table name or region mismatch | Run `aws dynamodb describe-table --table-name <name>` manually. | Update the table configuration or IAM policy. |
+| S3 check fails | Missing write/delete permissions | Attempt `aws s3 cp` with the same prefix. | Grant `s3:PutObject` and `s3:DeleteObject` on the prefix. |
+| Webhook secret empty | Environment variable unset or empty secret payload | Inspect `WEBHOOK_SECRET` / `WEBHOOK_SECRET_ARN` or fetch the secret in the console. | Set the environment variable or update the secret payload. |
+| Cleanup warning present | Delete operation failed (S3 or DynamoDB) | Review CloudTrail events for the sentinel key/item. | Grant delete permissions or clean up manually. |
+
+## Historian Anchors
+
+- Store the readiness JSON alongside audit artifacts for traceability.
+- Tag ledger entries with `health_schema=health.v1` to make future schema migrations explicit.

--- a/docs/schemas/health.v1.json
+++ b/docs/schemas/health.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReleaseCopilot readiness report",
+  "type": "object",
+  "required": [
+    "version",
+    "timestamp",
+    "overall",
+    "checks"
+  ],
+  "properties": {
+    "version": {"const": "health.v1"},
+    "timestamp": {"type": "string"},
+    "overall": {"enum": ["pass", "fail"]},
+    "cleanup_warning": {"type": "string"},
+    "dry_run": {"type": "boolean"},
+    "checks": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9_]+$": {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": {"enum": ["pass", "fail"]},
+            "resource": {"type": "string"},
+            "reason": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ constructs==10.3.0
 python-dotenv>=1.0.0
 ruff==0.5.7
 pytest==8.3.3
+jsonschema>=4.23.0

--- a/src/cli/health.py
+++ b/src/cli/health.py
@@ -1,0 +1,152 @@
+"""CLI helpers for the ``rc health`` command."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from releasecopilot.logging_config import get_logger
+
+from ..config.loader import (
+    Defaults,
+    get_aws_region,
+    get_dynamodb_table,
+    get_s3_destination,
+    get_secrets_mapping,
+    load_config,
+)
+from ..ops.health import ReadinessOptions, run_readiness
+
+LOGGER = get_logger(__name__)
+
+
+class HealthCommandError(RuntimeError):
+    """Raised when health command execution fails."""
+
+
+def register_health_parser(subparsers: argparse._SubParsersAction, defaults: Defaults) -> None:
+    parser = subparsers.add_parser(
+        "health",
+        help="Operational health checks",
+    )
+    parser.add_argument(
+        "--readiness",
+        action="store_true",
+        help="Run readiness checks against AWS dependencies",
+    )
+    parser.add_argument(
+        "--bucket",
+        help="Override S3 bucket or s3://bucket/prefix for the sentinel probe",
+    )
+    parser.add_argument(
+        "--table",
+        help="Override DynamoDB table name for the sentinel probe",
+    )
+    parser.add_argument(
+        "--secrets",
+        help="Comma-separated logical secret names or ARNs to validate",
+    )
+    parser.add_argument(
+        "--json",
+        help="Write readiness JSON output to the provided path instead of stdout",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Describe planned checks without calling AWS APIs",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
+    parser.add_argument(
+        "--config",
+        help="Optional settings file override (defaults to config/settings.yaml)",
+        default=str(defaults.settings_path),
+    )
+
+
+def run_health_command(args: argparse.Namespace, defaults: Defaults) -> int:
+    if not args.readiness:
+        raise HealthCommandError("Specify --readiness to run readiness checks")
+
+    config = load_config(args.config)
+    region = get_aws_region(config)
+    bucket, prefix = _resolve_bucket(args.bucket, config)
+    table_name = args.table or get_dynamodb_table(config)
+    secrets_map = get_secrets_mapping(config)
+    secrets = _select_secrets(args.secrets, secrets_map)
+
+    webhook_secret_id = os.getenv("WEBHOOK_SECRET_ARN") or secrets_map.get("webhook")
+    webhook_env_present = bool(os.getenv("WEBHOOK_SECRET"))
+
+    options = ReadinessOptions(
+        region=region,
+        bucket=bucket,
+        prefix=prefix,
+        table_name=table_name,
+        secrets=secrets,
+        webhook_secret_id=webhook_secret_id,
+        webhook_env_present=webhook_env_present,
+        dry_run=args.dry_run,
+    )
+
+    LOGGER.debug(
+        "Executing readiness checks",
+        extra={
+            "bucket": bucket,
+            "prefix": prefix,
+            "table": table_name,
+            "secrets": list(secrets.keys()),
+            "webhook_secret": bool(webhook_secret_id),
+            "dry_run": args.dry_run,
+        },
+    )
+
+    report = run_readiness(options)
+    payload = json.dumps(report.as_dict(), indent=2)
+
+    if args.json:
+        output_path = Path(args.json).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload, encoding="utf-8")
+        LOGGER.info("Wrote readiness output", extra={"path": str(output_path)})
+    else:
+        print(payload)
+
+    return 0 if report.is_success() else 1
+
+
+def _resolve_bucket(value: str | None, config: dict) -> tuple[str | None, str | None]:
+    if value:
+        if value.startswith("s3://"):
+            trimmed = value[5:]
+            if "/" in trimmed:
+                bucket, prefix = trimmed.split("/", 1)
+                return bucket, prefix
+            return trimmed, None
+        return value, None
+
+    bucket, prefix = get_s3_destination(config)
+    return bucket, prefix
+
+
+def _select_secrets(override: str | None, configured: dict[str, str]) -> dict[str, str]:
+    if not override:
+        return dict(configured)
+
+    selected: dict[str, str] = {}
+    for entry in override.split(","):
+        name = entry.strip()
+        if not name:
+            continue
+        secret_id = configured.get(name)
+        if secret_id:
+            selected[name] = secret_id
+        else:
+            selected[name] = name
+    return selected
+
+
+__all__ = ["register_health_parser", "run_health_command", "HealthCommandError"]

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -5,11 +5,19 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import yaml
 
-__all__ = ["Defaults", "load_defaults", "load_config"]
+__all__ = [
+    "Defaults",
+    "load_defaults",
+    "load_config",
+    "get_aws_region",
+    "get_s3_destination",
+    "get_dynamodb_table",
+    "get_secrets_mapping",
+]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SETTINGS_PATH = REPO_ROOT / "config" / "settings.yaml"
@@ -61,6 +69,59 @@ def load_config(path: Optional[str | Path] = None) -> Dict[str, Any]:
 
     target = Path(path) if path is not None else DEFAULT_SETTINGS_PATH
     return _load_settings_file(target)
+
+
+def get_aws_region(config: Mapping[str, Any], env: Mapping[str, str] | None = None) -> str | None:
+    """Return the AWS region derived from configuration or environment."""
+
+    env = env or os.environ
+    aws_config = config.get("aws", {}) if isinstance(config, Mapping) else {}
+    region = aws_config.get("region") if isinstance(aws_config, Mapping) else None
+    if region:
+        return str(region)
+    for key in ("AWS_REGION", "AWS_DEFAULT_REGION"):
+        if env.get(key):
+            return env[key]
+    return None
+
+
+def get_s3_destination(config: Mapping[str, Any]) -> Tuple[str | None, str | None]:
+    """Return the S3 bucket and prefix configured for artifacts."""
+
+    aws_config = config.get("aws", {}) if isinstance(config, Mapping) else {}
+    bucket = None
+    prefix = None
+    if isinstance(aws_config, Mapping):
+        bucket_value = aws_config.get("s3_bucket")
+        prefix_value = aws_config.get("s3_prefix")
+        bucket = str(bucket_value) if bucket_value else None
+        prefix = str(prefix_value) if prefix_value else None
+    return bucket, prefix
+
+
+def get_dynamodb_table(config: Mapping[str, Any]) -> str | None:
+    """Return the DynamoDB table name used for Jira webhook caches."""
+
+    jira_cfg = config.get("jira", {}) if isinstance(config, Mapping) else {}
+    if isinstance(jira_cfg, Mapping):
+        table_name = jira_cfg.get("issue_table_name")
+        return str(table_name) if table_name else None
+    return None
+
+
+def get_secrets_mapping(config: Mapping[str, Any]) -> Dict[str, str]:
+    """Return the configured Secrets Manager identifiers keyed by logical name."""
+
+    aws_config = config.get("aws", {}) if isinstance(config, Mapping) else {}
+    secrets = aws_config.get("secrets", {}) if isinstance(aws_config, Mapping) else {}
+    if not isinstance(secrets, Mapping):
+        return {}
+    resolved: Dict[str, str] = {}
+    for key, value in secrets.items():
+        if not isinstance(key, str) or not value:
+            continue
+        resolved[key] = str(value)
+    return resolved
 
 
 def load_defaults(env: Mapping[str, str] | None = None) -> Defaults:

--- a/src/ops/__init__.py
+++ b/src/ops/__init__.py
@@ -1,0 +1,5 @@
+"""Operational utilities for ReleaseCopilot."""
+
+from .health import ReadinessOptions, ReadinessReport, run_readiness
+
+__all__ = ["ReadinessOptions", "ReadinessReport", "run_readiness"]

--- a/src/ops/health.py
+++ b/src/ops/health.py
@@ -1,0 +1,364 @@
+"""Readiness checks for ReleaseCopilot operational environments."""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, MutableMapping
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from releasecopilot.logging_config import get_logger
+from releasecopilot.uploader import build_s3_client, put_object
+
+LOGGER = get_logger(__name__)
+
+HEALTH_VERSION = "health.v1"
+
+
+@dataclass(frozen=True)
+class ReadinessClients:
+    """Container for AWS clients used during readiness checks."""
+
+    secrets: Any | None = None
+    dynamodb: Any | None = None
+    s3: Any | None = None
+
+
+@dataclass(frozen=True)
+class ReadinessOptions:
+    """Configuration parameters driving the readiness workflow."""
+
+    region: str | None
+    bucket: str | None
+    prefix: str | None
+    table_name: str | None
+    secrets: Mapping[str, str]
+    webhook_secret_id: str | None
+    webhook_env_present: bool
+    dry_run: bool = False
+    clients: ReadinessClients | None = None
+
+
+@dataclass
+class CheckResult:
+    """Normalized representation of a readiness check outcome."""
+
+    status: str
+    resource: str | None = None
+    reason: str | None = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"status": self.status}
+        if self.resource:
+            payload["resource"] = self.resource
+        if self.reason:
+            payload["reason"] = self.reason
+        return payload
+
+
+@dataclass
+class ReadinessReport:
+    """Structured payload summarising readiness checks."""
+
+    version: str
+    timestamp: str
+    overall: str
+    checks: Dict[str, Dict[str, Any]]
+    cleanup_warning: str | None = None
+    dry_run: bool = False
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "version": self.version,
+            "timestamp": self.timestamp,
+            "overall": self.overall,
+            "checks": self.checks,
+        }
+        if self.cleanup_warning:
+            payload["cleanup_warning"] = self.cleanup_warning
+        if self.dry_run:
+            payload["dry_run"] = True
+        return payload
+
+    def is_success(self) -> bool:
+        """Return ``True`` when all checks succeeded."""
+
+        return self.overall == "pass"
+
+
+def run_readiness(options: ReadinessOptions) -> ReadinessReport:
+    """Execute readiness checks returning a structured report."""
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    clients = options.clients or _build_clients(options.region)
+    cleanup_messages: list[str] = []
+
+    secret_result, secret_state = _check_secrets(options, clients)
+    dynamo_result, dynamo_warning = _check_dynamodb(options, clients)
+    if dynamo_warning:
+        cleanup_messages.append(dynamo_warning)
+    s3_result, s3_warning = _check_s3(options, clients)
+    if s3_warning:
+        cleanup_messages.append(s3_warning)
+    webhook_result = _check_webhook(options, clients, secret_state)
+
+    checks = {
+        "secrets": secret_result.as_dict(),
+        "dynamodb": dynamo_result.as_dict(),
+        "s3": s3_result.as_dict(),
+        "webhook_secret": webhook_result.as_dict(),
+    }
+
+    overall = "pass"
+    for result in (secret_result, dynamo_result, s3_result, webhook_result):
+        if result.status != "pass":
+            overall = "fail"
+            break
+
+    report = ReadinessReport(
+        version=HEALTH_VERSION,
+        timestamp=timestamp,
+        overall=overall,
+        checks=checks,
+        cleanup_warning="; ".join(cleanup_messages) if cleanup_messages else None,
+        dry_run=options.dry_run,
+    )
+    return report
+
+
+def _build_clients(region: str | None) -> ReadinessClients:
+    return ReadinessClients(
+        secrets=boto3.client("secretsmanager", region_name=region),
+        dynamodb=boto3.client("dynamodb", region_name=region),
+        s3=build_s3_client(region_name=region),
+    )
+
+
+def _check_secrets(
+    options: ReadinessOptions, clients: ReadinessClients
+) -> tuple[CheckResult, MutableMapping[str, bool]]:
+    secret_status: MutableMapping[str, bool] = {}
+    if not options.secrets:
+        return CheckResult("pass", resource="secretsmanager://none", reason="No secrets requested"), secret_status
+
+    resource = ", ".join(
+        f"{name}={secret_id}" for name, secret_id in sorted(options.secrets.items())
+    )
+    if options.dry_run:
+        LOGGER.info("Skipping secrets check (dry-run)", extra={"secrets": list(options.secrets.keys())})
+        for secret_id in options.secrets.values():
+            secret_status[secret_id] = True
+        return (
+            CheckResult("pass", resource=f"secretsmanager://{resource}", reason="Dry-run"),
+            secret_status,
+        )
+
+    failures: list[str] = []
+    for name, secret_id in options.secrets.items():
+        try:
+            response = clients.secrets.get_secret_value(SecretId=secret_id)
+        except (BotoCoreError, ClientError) as exc:
+            LOGGER.error(
+                "Failed to read secret",
+                extra={"secret_name": name, "secret_id": secret_id, "error": str(exc)},
+            )
+            failures.append(f"{name}: unable to read secret ({exc.__class__.__name__})")
+            secret_status[secret_id] = False
+            continue
+
+        has_payload = bool(response.get("SecretString") or response.get("SecretBinary"))
+        secret_status[secret_id] = has_payload
+        if not has_payload:
+            LOGGER.error(
+                "Secret payload was empty",
+                extra={"secret_name": name, "secret_id": secret_id},
+            )
+            failures.append(f"{name}: secret payload empty")
+        else:
+            LOGGER.info(
+                "Secret validated",
+                extra={"secret_name": name, "secret_id": secret_id},
+            )
+
+    status = "fail" if failures else "pass"
+    reason = "; ".join(failures) if failures else None
+    return CheckResult(status, resource=f"secretsmanager://{resource}", reason=reason), secret_status
+
+
+def _check_webhook(
+    options: ReadinessOptions,
+    clients: ReadinessClients,
+    secret_status: Mapping[str, bool],
+) -> CheckResult:
+    env_name = "WEBHOOK_SECRET"
+    if options.dry_run:
+        return CheckResult("pass", resource="webhook-secret", reason="Dry-run")
+
+    if options.webhook_env_present:
+        LOGGER.info("Webhook secret resolved from environment", extra={"source": env_name})
+        return CheckResult("pass", resource=f"env://{env_name}")
+
+    secret_id = options.webhook_secret_id
+    if not secret_id:
+        LOGGER.error("Webhook secret is not configured")
+        return CheckResult("fail", resource="webhook-secret", reason="Webhook secret not configured")
+
+    if secret_status.get(secret_id) is True:
+        return CheckResult("pass", resource=f"secretsmanager://{secret_id}")
+    if secret_status.get(secret_id) is False:
+        return CheckResult("fail", resource=f"secretsmanager://{secret_id}", reason="Webhook secret payload empty")
+
+    try:
+        response = clients.secrets.get_secret_value(SecretId=secret_id)
+    except (BotoCoreError, ClientError) as exc:
+        LOGGER.error(
+            "Failed to resolve webhook secret",
+            extra={"secret_id": secret_id, "error": str(exc)},
+        )
+        return CheckResult("fail", resource=f"secretsmanager://{secret_id}", reason="Unable to fetch webhook secret")
+
+    has_payload = bool(response.get("SecretString") or response.get("SecretBinary"))
+    if not has_payload:
+        LOGGER.error(
+            "Webhook secret payload empty",
+            extra={"secret_id": secret_id},
+        )
+        return CheckResult("fail", resource=f"secretsmanager://{secret_id}", reason="Webhook secret payload empty")
+
+    return CheckResult("pass", resource=f"secretsmanager://{secret_id}")
+
+
+def _check_dynamodb(
+    options: ReadinessOptions, clients: ReadinessClients
+) -> tuple[CheckResult, str | None]:
+    table_name = options.table_name
+    if not table_name:
+        LOGGER.error("DynamoDB table name is not configured")
+        return CheckResult("fail", resource="dynamodb://", reason="Missing table name"), None
+
+    if options.dry_run:
+        return CheckResult("pass", resource=f"dynamodb://{table_name}", reason="Dry-run"), None
+
+    client = clients.dynamodb
+    try:
+        description = client.describe_table(TableName=table_name)["Table"]
+    except (BotoCoreError, ClientError) as exc:
+        LOGGER.error(
+            "Failed to describe DynamoDB table",
+            extra={"table_name": table_name, "error": str(exc)},
+        )
+        return (
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="DescribeTable failed"),
+            None,
+        )
+
+    key_schema = description.get("KeySchema") or []
+    attr_defs = {definition["AttributeName"]: definition["AttributeType"] for definition in description.get("AttributeDefinitions", [])}
+    if not key_schema:
+        LOGGER.error("Table key schema missing", extra={"table_name": table_name})
+        return (
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="Missing key schema"),
+            None,
+        )
+
+    sentinel = f"rc-health-{uuid.uuid4().hex}"
+    item: Dict[str, Dict[str, str]] = {}
+    for element in key_schema:
+        name = element.get("AttributeName")
+        attr_type = attr_defs.get(name, "S")
+        item[name] = _ddb_attribute(attr_type, sentinel)
+
+    try:
+        client.put_item(TableName=table_name, Item=item)
+        LOGGER.info("Wrote DynamoDB sentinel item", extra={"table_name": table_name})
+    except (BotoCoreError, ClientError) as exc:
+        LOGGER.error(
+            "Failed to write DynamoDB sentinel item",
+            extra={"table_name": table_name, "error": str(exc)},
+        )
+        return (
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="PutItem failed"),
+            None,
+        )
+
+    cleanup_warning: str | None = None
+    try:
+        client.delete_item(TableName=table_name, Key=item)
+    except (BotoCoreError, ClientError) as exc:
+        cleanup_warning = f"Failed to delete DynamoDB sentinel ({exc.__class__.__name__})"
+        LOGGER.warning(
+            "Failed to delete DynamoDB sentinel",
+            extra={"table_name": table_name, "error": str(exc)},
+        )
+    else:
+        LOGGER.info("Deleted DynamoDB sentinel item", extra={"table_name": table_name})
+
+    return CheckResult("pass", resource=f"dynamodb://{table_name}"), cleanup_warning
+
+
+def _ddb_attribute(attr_type: str, sentinel: str) -> Dict[str, str]:
+    if attr_type == "N":
+        return {"N": str(int(time.time()))}
+    if attr_type == "B":
+        return {"B": sentinel.encode("utf-8")}
+    return {"S": sentinel}
+
+
+def _check_s3(
+    options: ReadinessOptions, clients: ReadinessClients
+) -> tuple[CheckResult, str | None]:
+    bucket = options.bucket
+    if not bucket:
+        LOGGER.error("S3 bucket is not configured")
+        return CheckResult("fail", resource="s3://", reason="Missing bucket"), None
+
+    prefix = options.prefix.strip("/") if options.prefix else ""
+    if options.dry_run:
+        resource = f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+        return CheckResult("pass", resource=resource, reason="Dry-run"), None
+
+    client = clients.s3
+    sentinel = uuid.uuid4().hex
+    key_parts = [part for part in (prefix, "health", "readiness", f"{sentinel}.txt") if part]
+    key = "/".join(key_parts)
+    resource = f"s3://{bucket}/{key}"
+
+    try:
+        put_object(
+            bucket=bucket,
+            key=key,
+            body="releasecopilot-readiness",
+            client=client,
+        )
+        LOGGER.info("Uploaded S3 sentinel object", extra={"bucket": bucket, "key": key})
+    except (BotoCoreError, ClientError) as exc:
+        LOGGER.error(
+            "Failed to upload S3 sentinel object",
+            extra={"bucket": bucket, "key": key, "error": str(exc)},
+        )
+        return CheckResult("fail", resource=resource, reason="PutObject failed"), None
+
+    cleanup_warning: str | None = None
+    try:
+        client.delete_object(Bucket=bucket, Key=key)
+        LOGGER.info("Deleted S3 sentinel object", extra={"bucket": bucket, "key": key})
+    except (BotoCoreError, ClientError) as exc:
+        cleanup_warning = f"Failed to delete S3 sentinel ({exc.__class__.__name__})"
+        LOGGER.warning(
+            "Failed to delete S3 sentinel object",
+            extra={"bucket": bucket, "key": key, "error": str(exc)},
+        )
+
+    return CheckResult("pass", resource=resource), cleanup_warning
+
+
+__all__ = [
+    "HEALTH_VERSION",
+    "ReadinessClients",
+    "ReadinessOptions",
+    "ReadinessReport",
+    "run_readiness",
+]

--- a/src/releasecopilot/uploader.py
+++ b/src/releasecopilot/uploader.py
@@ -17,6 +17,28 @@ def build_s3_client(*, region_name: Optional[str] = None):
     return boto3.client("s3", region_name=region_name)
 
 
+def put_object(
+    bucket: str,
+    key: str,
+    body: bytes | str,
+    *,
+    client=None,
+    region_name: Optional[str] = None,
+    content_type: Optional[str] = None,
+    metadata: Optional[Dict[str, str]] = None,
+) -> None:
+    """Write a single object to S3 using server-side encryption."""
+
+    client = client or build_s3_client(region_name=region_name)
+    payload = body.encode("utf-8") if isinstance(body, str) else body
+    extra_args: Dict[str, str] = {"ServerSideEncryption": "AES256"}
+    if content_type:
+        extra_args["ContentType"] = content_type
+    if metadata:
+        extra_args["Metadata"] = {key: str(value) for key, value in metadata.items() if value is not None}
+    client.put_object(Bucket=bucket, Key=key, Body=payload, **extra_args)
+
+
 def upload_directory(
     bucket: str,
     prefix: str,
@@ -99,5 +121,5 @@ def _guess_content_type(path: Path) -> Optional[str]:
     return None
 
 
-__all__ = ["build_s3_client", "upload_directory"]
+__all__ = ["build_s3_client", "put_object", "upload_directory"]
 

--- a/tests/cli/test_rc_health.py
+++ b/tests/cli/test_rc_health.py
@@ -1,0 +1,142 @@
+"""Unit tests for the ``rc health`` CLI entry point."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.cli import app
+from src.config.loader import load_defaults
+from src.ops.health import ReadinessOptions, ReadinessReport
+
+
+@pytest.fixture(name="defaults")
+def _defaults_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    project_root = tmp_path
+    config_dir = project_root / "config"
+    config_dir.mkdir()
+    settings_path = config_dir / "settings.yaml"
+    settings_path.write_text(
+        """
+aws:
+  region: us-east-1
+  s3_bucket: releasecopilot-artifacts
+  s3_prefix: readiness
+  secrets:
+    jira: secret/jira
+    webhook: secret/webhook
+jira:
+  issue_table_name: releasecopilot-jira
+""".strip(),
+        encoding="utf-8",
+    )
+
+    env = {
+        "RC_ROOT": str(project_root),
+        "RC_CACHE_DIR": str(project_root / "cache"),
+        "RC_ARTIFACT_DIR": str(project_root / "dist"),
+        "RC_REPORTS_DIR": str(project_root / "reports"),
+        "RC_SETTINGS_FILE": str(settings_path),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return load_defaults(env)
+
+
+def _report(overall: str = "pass", dry_run: bool = False) -> ReadinessReport:
+    return ReadinessReport(
+        version="health.v1",
+        timestamp="2024-01-01T00:00:00Z",
+        overall=overall,
+        checks={
+            "secrets": {"status": "pass"},
+            "dynamodb": {"status": "pass"},
+            "s3": {"status": "pass"},
+            "webhook_secret": {"status": "pass"},
+        },
+        cleanup_warning=None,
+        dry_run=dry_run,
+    )
+
+
+def test_health_readiness_prints_report(monkeypatch: pytest.MonkeyPatch, defaults, capsys):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+    def _fake_run(options: ReadinessOptions):
+        return _report()
+
+    monkeypatch.setattr("src.cli.health.run_readiness", _fake_run)
+
+    exit_code = app.main(["health", "--readiness"], defaults=defaults)
+    assert exit_code == 0
+
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+    assert payload["overall"] == "pass"
+    assert payload["checks"]["s3"]["status"] == "pass"
+
+
+def test_health_readiness_writes_json(monkeypatch: pytest.MonkeyPatch, defaults, tmp_path: Path):
+    output_path = tmp_path / "health.json"
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+    monkeypatch.setattr("src.cli.health.run_readiness", lambda options: _report())
+
+    exit_code = app.main(
+        ["health", "--readiness", "--json", str(output_path)],
+        defaults=defaults,
+    )
+    assert exit_code == 0
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["overall"] == "pass"
+
+
+def test_health_readiness_respects_overrides(monkeypatch: pytest.MonkeyPatch, defaults):
+    captured: dict[str, ReadinessOptions] = {}
+
+    def _capture(options: ReadinessOptions):
+        captured["options"] = options
+        return _report(dry_run=True)
+
+    monkeypatch.setattr("src.cli.health.run_readiness", _capture)
+
+    exit_code = app.main(
+        [
+            "health",
+            "--readiness",
+            "--bucket",
+            "s3://custom/reports",
+            "--table",
+            "custom-table",
+            "--secrets",
+            "jira,external/secret",
+            "--dry-run",
+        ],
+        defaults=defaults,
+    )
+
+    assert exit_code == 0
+    options = captured["options"]
+    assert options.bucket == "custom"
+    assert options.prefix == "reports"
+    assert options.table_name == "custom-table"
+    assert options.dry_run is True
+    assert options.secrets["jira"] == "secret/jira"
+    assert options.secrets["external/secret"] == "external/secret"
+
+
+def test_health_requires_readiness_flag(monkeypatch: pytest.MonkeyPatch, defaults, capsys):
+    monkeypatch.setattr("src.cli.health.run_readiness", lambda options: _report())
+
+    exit_code = app.main(["health"], defaults=defaults)
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "--readiness" in stderr

--- a/tests/ops/test_health_checks.py
+++ b/tests/ops/test_health_checks.py
@@ -1,0 +1,325 @@
+"""Unit tests for readiness health checks."""
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+
+import boto3
+import pytest
+from botocore.stub import ANY, Stubber
+
+from src.ops.health import ReadinessClients, ReadinessOptions, run_readiness
+
+
+@pytest.fixture(autouse=True)
+def _aws_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+
+def _clients(region: str = "us-east-1") -> ReadinessClients:
+    return ReadinessClients(
+        secrets=boto3.client("secretsmanager", region_name=region),
+        dynamodb=boto3.client("dynamodb", region_name=region),
+        s3=boto3.client("s3", region_name=region),
+    )
+
+
+def test_run_readiness_success() -> None:
+    clients = _clients()
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="releasecopilot-artifacts",
+        prefix="reports",
+        table_name="releasecopilot-jira",
+        secrets={"jira": "secret/jira"},
+        webhook_secret_id="secret/webhook",
+        webhook_env_present=False,
+        clients=clients,
+    )
+
+    with ExitStack() as stack:
+        secrets_stub = stack.enter_context(Stubber(clients.secrets))
+        ddb_stub = stack.enter_context(Stubber(clients.dynamodb))
+        s3_stub = stack.enter_context(Stubber(clients.s3))
+
+        secrets_stub.add_response(
+            "get_secret_value",
+            {"SecretString": json.dumps({"token": "value"})},
+            {"SecretId": "secret/jira"},
+        )
+        secrets_stub.add_response(
+            "get_secret_value",
+            {"SecretString": "webhook"},
+            {"SecretId": "secret/webhook"},
+        )
+
+        ddb_stub.add_response(
+            "describe_table",
+            {
+                "Table": {
+                    "TableName": options.table_name,
+                    "KeySchema": [{"AttributeName": "issue_id", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "issue_id", "AttributeType": "S"}],
+                }
+            },
+            {"TableName": options.table_name},
+        )
+        ddb_stub.add_response(
+            "put_item",
+            {},
+            {"TableName": options.table_name, "Item": {"issue_id": {"S": ANY}}},
+        )
+        ddb_stub.add_response(
+            "delete_item",
+            {},
+            {"TableName": options.table_name, "Key": {"issue_id": {"S": ANY}}},
+        )
+
+        s3_stub.add_response(
+            "put_object",
+            {},
+            {
+                "Bucket": options.bucket,
+                "Key": ANY,
+                "Body": b"releasecopilot-readiness",
+                "ServerSideEncryption": "AES256",
+            },
+        )
+        s3_stub.add_response(
+            "delete_object",
+            {},
+            {"Bucket": options.bucket, "Key": ANY},
+        )
+
+        report = run_readiness(options)
+
+    assert report.is_success()
+    assert report.cleanup_warning is None
+    assert report.checks["secrets"]["status"] == "pass"
+    assert report.checks["dynamodb"]["status"] == "pass"
+    assert report.checks["s3"]["status"] == "pass"
+    assert report.checks["webhook_secret"]["status"] == "pass"
+
+
+def test_readiness_reports_secret_failure() -> None:
+    clients = _clients()
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="bucket",
+        prefix=None,
+        table_name="table",
+        secrets={"jira": "secret/missing"},
+        webhook_secret_id="secret/webhook",
+        webhook_env_present=True,
+        clients=clients,
+    )
+
+    with ExitStack() as stack:
+        secrets_stub = stack.enter_context(Stubber(clients.secrets))
+        ddb_stub = stack.enter_context(Stubber(clients.dynamodb))
+        s3_stub = stack.enter_context(Stubber(clients.s3))
+
+        secrets_stub.add_client_error(
+            "get_secret_value",
+            service_error_code="ResourceNotFoundException",
+            expected_params={"SecretId": "secret/missing"},
+        )
+
+        ddb_stub.add_response(
+            "describe_table",
+            {
+                "Table": {
+                    "TableName": options.table_name,
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                }
+            },
+            {"TableName": options.table_name},
+        )
+        ddb_stub.add_response(
+            "put_item",
+            {},
+            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+        )
+        ddb_stub.add_response(
+            "delete_item",
+            {},
+            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+        )
+
+        s3_stub.add_response(
+            "put_object",
+            {},
+            {
+                "Bucket": options.bucket,
+                "Key": ANY,
+                "Body": b"releasecopilot-readiness",
+                "ServerSideEncryption": "AES256",
+            },
+        )
+        s3_stub.add_response(
+            "delete_object",
+            {},
+            {"Bucket": options.bucket, "Key": ANY},
+        )
+
+        report = run_readiness(options)
+
+    assert not report.is_success()
+    assert report.checks["secrets"]["status"] == "fail"
+    assert "unable to read" in report.checks["secrets"].get("reason", "")
+
+
+def test_webhook_missing_fails() -> None:
+    clients = _clients()
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="bucket",
+        prefix="health",
+        table_name="table",
+        secrets={},
+        webhook_secret_id=None,
+        webhook_env_present=False,
+        clients=clients,
+    )
+
+    with ExitStack() as stack:
+        ddb_stub = stack.enter_context(Stubber(clients.dynamodb))
+        s3_stub = stack.enter_context(Stubber(clients.s3))
+
+        ddb_stub.add_response(
+            "describe_table",
+            {
+                "Table": {
+                    "TableName": options.table_name,
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                }
+            },
+            {"TableName": options.table_name},
+        )
+        ddb_stub.add_response(
+            "put_item",
+            {},
+            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+        )
+        ddb_stub.add_response(
+            "delete_item",
+            {},
+            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+        )
+
+        s3_stub.add_response(
+            "put_object",
+            {},
+            {
+                "Bucket": options.bucket,
+                "Key": ANY,
+                "Body": b"releasecopilot-readiness",
+                "ServerSideEncryption": "AES256",
+            },
+        )
+        s3_stub.add_response(
+            "delete_object",
+            {},
+            {"Bucket": options.bucket, "Key": ANY},
+        )
+
+        report = run_readiness(options)
+
+    assert not report.is_success()
+    assert report.checks["webhook_secret"]["status"] == "fail"
+    assert "not configured" in report.checks["webhook_secret"].get("reason", "")
+
+
+def test_s3_cleanup_warning() -> None:
+    clients = _clients()
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="bucket",
+        prefix=None,
+        table_name="table",
+        secrets={},
+        webhook_secret_id="secret/webhook",
+        webhook_env_present=True,
+        clients=clients,
+    )
+
+    with ExitStack() as stack:
+        secrets_stub = stack.enter_context(Stubber(clients.secrets))
+        ddb_stub = stack.enter_context(Stubber(clients.dynamodb))
+        s3_stub = stack.enter_context(Stubber(clients.s3))
+
+        secrets_stub.add_response(
+            "get_secret_value",
+            {"SecretString": "token"},
+            {"SecretId": "secret/webhook"},
+        )
+
+        ddb_stub.add_response(
+            "describe_table",
+            {
+                "Table": {
+                    "TableName": options.table_name,
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                }
+            },
+            {"TableName": options.table_name},
+        )
+        ddb_stub.add_response(
+            "put_item",
+            {},
+            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+        )
+        ddb_stub.add_response(
+            "delete_item",
+            {},
+            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+        )
+
+        s3_stub.add_response(
+            "put_object",
+            {},
+            {
+                "Bucket": options.bucket,
+                "Key": ANY,
+                "Body": b"releasecopilot-readiness",
+                "ServerSideEncryption": "AES256",
+            },
+        )
+        s3_stub.add_client_error(
+            "delete_object",
+            service_error_code="AccessDenied",
+            expected_params={"Bucket": options.bucket, "Key": ANY},
+        )
+
+        report = run_readiness(options)
+
+    assert report.is_success()
+    assert report.cleanup_warning is not None
+    assert "S3" in report.cleanup_warning
+
+
+def test_dry_run_skips_aws_calls() -> None:
+    clients = _clients()
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="bucket",
+        prefix="prefix",
+        table_name="table",
+        secrets={"jira": "secret/jira"},
+        webhook_secret_id="secret/webhook",
+        webhook_env_present=False,
+        dry_run=True,
+        clients=clients,
+    )
+
+    report = run_readiness(options)
+
+    assert report.is_success()
+    assert report.dry_run is True
+    for check in report.checks.values():
+        assert check["status"] == "pass"

--- a/tests/ops/test_health_contract.py
+++ b/tests/ops/test_health_contract.py
@@ -1,0 +1,42 @@
+"""Contract tests for readiness JSON payloads."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from src.ops.health import ReadinessClients, ReadinessOptions, run_readiness
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _schema() -> dict:
+    schema_path = REPO_ROOT / "docs" / "schemas" / "health.v1.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def test_example_payload_matches_schema() -> None:
+    example_path = REPO_ROOT / "docs" / "examples" / "health" / "health-pass.v1.json"
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=example, schema=_schema())
+
+
+def test_dry_run_report_matches_schema(monkeypatch) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    options = ReadinessOptions(
+        region="us-east-1",
+        bucket="bucket",
+        prefix="prefix",
+        table_name="table",
+        secrets={"jira": "secret/jira"},
+        webhook_secret_id="secret/webhook",
+        webhook_env_present=False,
+        dry_run=True,
+        clients=ReadinessClients(secrets=None, dynamodb=None, s3=None),
+    )
+
+    report = run_readiness(options)
+    jsonschema.validate(instance=report.as_dict(), schema=_schema())


### PR DESCRIPTION
## Summary
- add an `rc health --readiness` CLI entry point that loads shared defaults and emits structured JSON
- implement AWS Secrets Manager, DynamoDB, S3, and webhook sentinel checks plus a reusable S3 put helper
- document the readiness workflow with schema/runbook updates and cover success and failure paths with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e13e52e898832f938ee129467d36b5