### PR TITLE
Ensure Lambda handlers use shared logging

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -34,6 +34,11 @@ Common secret tokens (e.g., values containing "token", "secret", "password",
 "key", or "authorization") are automatically redacted to prevent accidental
 exposure in logs.
 
+All AWS Lambda entrypoints import the shared logging configuration during cold
+starts. This ensures every function emits logs through the same filter chain
+and inherits the redaction guarantees above without requiring per-function
+customisation.
+
 ## Retry behaviour
 
 Jira and Bitbucket HTTP calls are protected with exponential backoff and

--- a/services/ingest/jira_ingestor/handler.py
+++ b/services/ingest/jira_ingestor/handler.py
@@ -1,14 +1,16 @@
 import datetime as dt
 import json
-import logging
 import os
 import time
 import boto3
 from jira_api import refresh_access_token, search_page, discover_field_map, get_all_comments_if_needed
 from adf_md import to_markdown
 
-log = logging.getLogger()
-log.setLevel(logging.INFO)
+from releasecopilot.logging_config import configure_logging, get_logger
+
+
+configure_logging()
+LOGGER = get_logger(__name__)
 
 secrets = boto3.client("secretsmanager")
 ssm = boto3.client("ssm")
@@ -112,7 +114,7 @@ def handler(event, context):
 
     cursor = _load_cursor()
     jql = f'updated >= "{cursor}" ORDER BY updated ASC'
-    log.info(f"JQL: {jql}")
+    LOGGER.info(f"JQL: {jql}")
     start = 0
     last_seen = cursor
     total_processed = 0

--- a/services/jira_reconciliation_job/handler.py
+++ b/services/jira_reconciliation_job/handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import base64
 import json
-import logging
 import os
 import time
 from dataclasses import dataclass
@@ -14,10 +13,11 @@ from urllib import error, parse, request
 import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
+from releasecopilot.logging_config import configure_logging, get_logger
 
 
-LOGGER = logging.getLogger()
-LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO"))
+configure_logging()
+LOGGER = get_logger(__name__)
 
 TABLE_NAME = os.environ["TABLE_NAME"]
 JIRA_BASE_URL = os.getenv("JIRA_BASE_URL", "https://your-domain.atlassian.net").rstrip("/")

--- a/services/jira_sync_webhook/handler.py
+++ b/services/jira_sync_webhook/handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import base64
 import json
-import logging
 import os
 import time
 from datetime import datetime, timezone
@@ -11,10 +10,11 @@ from typing import Any, Dict, Optional
 
 import boto3
 from botocore.exceptions import ClientError
+from releasecopilot.logging_config import configure_logging, get_logger
 
 
-LOGGER = logging.getLogger()
-LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO"))
+configure_logging()
+LOGGER = get_logger(__name__)
 
 TABLE_NAME = os.environ["TABLE_NAME"]
 WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET")

--- a/tests/services/test_jira_sync_webhook_logging.py
+++ b/tests/services/test_jira_sync_webhook_logging.py
@@ -1,0 +1,84 @@
+import importlib
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging(monkeypatch):
+    monkeypatch.setenv("RC_LOG_JSON", "true")
+    monkeypatch.setenv("RC_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    if "releasecopilot.logging_config" in sys.modules:
+        importlib.reload(sys.modules["releasecopilot.logging_config"])
+    else:
+        importlib.import_module("releasecopilot.logging_config")
+    yield
+    # Ensure we clean up handlers between tests
+    if "releasecopilot.logging_config" in sys.modules:
+        importlib.reload(sys.modules["releasecopilot.logging_config"])
+
+
+def _reload_module(module_name: str):
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def _collect_logs(capsys):
+    output = capsys.readouterr().out.strip().splitlines()
+    return [json.loads(line) for line in output if line.strip()]
+
+
+def test_webhook_handler_redacts_sensitive_event_fields(monkeypatch, capsys):
+    monkeypatch.setenv("TABLE_NAME", "jira-webhook-test")
+    handler = _reload_module("services.jira_sync_webhook.handler")
+
+    event = {
+        "httpMethod": "POST",
+        "headers": {"Authorization": "Bearer super-secret-token"},
+        "body": json.dumps({"webhookEvent": "unknown", "password": "hunter2"}),
+        "isBase64Encoded": False,
+    }
+
+    handler.handler(event, None)
+
+    logs = _collect_logs(capsys)
+    received = next(payload for payload in logs if payload.get("message") == "Received event")
+    event_payload = received["event"]
+    assert event_payload["headers"]["Authorization"] == "***REDACTED***"
+    assert event_payload["body"] == "***REDACTED***"
+
+
+def test_reconciliation_handler_redacts_sensitive_event_fields(monkeypatch, capsys):
+    monkeypatch.setenv("TABLE_NAME", "jira-recon-test")
+    handler = _reload_module("services.jira_reconciliation_job.handler")
+
+    monkeypatch.setattr(handler, "_load_credentials", lambda: handler.JiraCredentials())
+    monkeypatch.setattr(handler, "_determine_fix_versions", lambda event: [])
+
+    class _DummySession:
+        def __init__(self, base_url, credentials):  # noqa: D401
+            self.base_url = base_url
+            self.credentials = credentials
+
+        def search(self, jql, *, fields=None):  # noqa: D401
+            return []
+
+    monkeypatch.setattr(handler, "JiraSession", _DummySession)
+
+    event = {
+        "fixVersions": [],
+        "headers": {"Authorization": "Basic super-secret"},
+        "client_secret": "abc123-secret",
+    }
+
+    handler.handler(event, None)
+
+    logs = _collect_logs(capsys)
+    received = next(payload for payload in logs if payload.get("message") == "Starting Jira reconciliation")
+    event_payload = received["event"]
+    assert event_payload["headers"]["Authorization"] == "***REDACTED***"
+    assert event_payload["client_secret"] == "***REDACTED***"


### PR DESCRIPTION
## Summary
- initialize the shared logging configuration in the Jira webhook, reconciliation job, and ingest Lambda handlers so they use `get_logger(__name__)`
- add regression tests that execute the Jira handlers with JSON logging enabled and assert sensitive fields are redacted
- document that Lambda functions reuse the central logger and automatically inherit redaction guarantees

## Testing
- pytest tests/services/test_jira_sync_webhook_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e165d2fa6c832f9cd8b802abc2cd91