### PR TITLE
feat: add composite jira cache keys with idempotency

### DIFF
--- a/clients/jira_store.py
+++ b/clients/jira_store.py
@@ -80,7 +80,14 @@ class JiraIssueStore:
             raise JiraQueryError("Failed to query Jira issue store", context=context) from exc
 
         issues: List[Dict[str, Any]] = []
+        seen_issue_keys: set[str] = set()
         for item in items:
+            issue_key = item.get("issue_key") or item.get("issue_id")
+            if not issue_key:
+                continue
+            if issue_key in seen_issue_keys:
+                continue
+            seen_issue_keys.add(issue_key)
             if item.get("deleted"):
                 continue
             issue_payload = item.get("issue")

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -55,3 +55,17 @@ is `429` or any `5xx`, or when a timeout/connection error occurs.
 Set `RC_DISABLE_RETRIES=true` to execute each request exactly once. This is
 useful during debugging or when operating against mock services that do not
 need retry protection.
+
+## Jira cache idempotency
+
+- Webhook ingestion stores every change under the composite DynamoDB key
+  `issue_key` + `updated_at`. An `idempotency_key` derived from the webhook
+  delivery identifier prevents duplicate sort keys when retries arrive.
+- Delete events update the latest sort key in place and flag the record as a
+  tombstone (`deleted=true`). Reconciliation performs the same mutation when it
+  discovers missing issues so downstream consumers can filter deletes via the
+  `deleted` attribute.
+- Consumers such as `clients.jira_store.JiraIssueStore` query secondary indexes
+  with `ScanIndexForward=False` and only emit the newest non-deleted version per
+  `issue_key`. Historical versions remain available for audits and replay
+  tooling.

--- a/docs/runbooks/health_smoke.md
+++ b/docs/runbooks/health_smoke.md
@@ -29,6 +29,11 @@ Optional flags:
 | `--config PATH` | Override the settings file used for defaults. |
 | `--log-level LEVEL` | Adjust logging verbosity (defaults to `INFO`). |
 
+The DynamoDB probe expects a composite key with both a HASH and RANGE element.
+If the health check reports `Missing range key`, confirm that the cache table
+has `issue_key` (HASH) and `updated_at` (RANGE) defined and that any overrides
+passed via `--table` point at the new schema.
+
 ### Sample Output
 
 ```json
@@ -79,6 +84,10 @@ readiness verdict to each deployment.
 | ------- | ------- | ----- |
 | Secrets Manager | `secretsmanager:GetSecretValue` | Specific release secrets (e.g. `arn:aws:secretsmanager:REGION:ACCOUNT:secret:releasecopilot/*`) |
 | DynamoDB | `DescribeTable`, `PutItem`, `DeleteItem` | ReleaseCopilot Jira cache table (e.g. `arn:aws:dynamodb:REGION:ACCOUNT:table/releasecopilot-jira-cache`) |
+
+> The readiness sentinel creates and deletes a single item using both key
+> attributes. Ensure IAM policies grant access to `PutItem`/`DeleteItem` on the
+> composite key, otherwise stale sentinel rows may accumulate.
 | S3 | `PutObject`, `DeleteObject` | Artifact bucket/prefix (e.g. `arn:aws:s3:::releasecopilot-artifacts/readiness/*`) |
 
 ## Troubleshooting

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -6,3 +6,14 @@ any entry point changes (for example `infra/cdk/app.py`) to ensure CI and local 
 
 Local commands such as `cdk synth` or `cdk deploy` can be executed from the repository root without supplying `-a`. The
 workflow installs the dependencies defined in `infra/cdk/requirements.txt` and then runs the CDK CLI directly.
+
+## Core Stack Outputs
+
+The `ReleaseCopilot-<env>-Core` stack provisions the S3 artifacts bucket,
+Secrets Manager placeholders, Lambda functions, API Gateway webhook, and the
+Jira DynamoDB cache. The cache table now uses a composite primary key of
+`issue_key` (HASH) and `updated_at` (RANGE) with point-in-time recovery enabled
+so that webhook replays remain idempotent. Global secondary indexes for
+`FixVersionIndex`, `StatusIndex`, and `AssigneeIndex` are unchanged. Stack
+outputs expose both the table name (`JiraTableName`) and ARN (`JiraTableArn`)
+so IAM deploy roles can scope DynamoDB permissions precisely.

--- a/infra/cdk/core_stack.py
+++ b/infra/cdk/core_stack.py
@@ -156,7 +156,10 @@ class CoreStack(Stack):
             self,
             "JiraIssuesTable",
             partition_key=dynamodb.Attribute(
-                name="issue_id", type=dynamodb.AttributeType.STRING
+                name="issue_key", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="updated_at", type=dynamodb.AttributeType.STRING
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.RETAIN,
@@ -332,6 +335,7 @@ class CoreStack(Stack):
         CfnOutput(self, "LambdaName", value=self.lambda_function.function_name)
         CfnOutput(self, "LambdaArn", value=self.lambda_function.function_arn)
         CfnOutput(self, "JiraTableName", value=self.jira_table.table_name)
+        CfnOutput(self, "JiraTableArn", value=self.jira_table.table_arn)
         CfnOutput(self, "JiraWebhookUrl", value=self.webhook_api.url)
         CfnOutput(self, "JiraReconciliationLambdaName", value=self.reconciliation_lambda.function_name)
         CfnOutput(self, "JiraReconciliationDlqArn", value=self.reconciliation_dlq.queue_arn)

--- a/main.py
+++ b/main.py
@@ -223,10 +223,7 @@ def build_jira_client(settings: Dict[str, Any]) -> JiraClient:
 
 def build_jira_store(settings: Dict[str, Any]) -> JiraIssueStore:
     storage_cfg = settings.get("storage", {})
-    table_name = (
-        storage_cfg.get("dynamodb", {}).get("jira_issue_table")
-        or settings.get("jira", {}).get("issue_table_name")
-    )
+    table_name = storage_cfg.get("dynamodb", {}).get("jira_issue_table")
     if not table_name:
         raise RuntimeError("Jira issue DynamoDB table name is not configured")
 

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -106,10 +106,19 @@ def get_s3_destination(config: Mapping[str, Any]) -> Tuple[str | None, str | Non
 def get_dynamodb_table(config: Mapping[str, Any]) -> str | None:
     """Return the DynamoDB table name used for Jira webhook caches."""
 
+    storage_cfg = config.get("storage", {}) if isinstance(config, Mapping) else {}
+    if isinstance(storage_cfg, Mapping):
+        dynamodb_cfg = storage_cfg.get("dynamodb", {}) if isinstance(storage_cfg, Mapping) else {}
+        if isinstance(dynamodb_cfg, Mapping):
+            table_name = dynamodb_cfg.get("jira_issue_table")
+            if table_name:
+                return str(table_name)
+
+    # Fallback to legacy location for backwards compatibility
     jira_cfg = config.get("jira", {}) if isinstance(config, Mapping) else {}
     if isinstance(jira_cfg, Mapping):
-        table_name = jira_cfg.get("issue_table_name")
-        return str(table_name) if table_name else None
+        legacy = jira_cfg.get("issue_table_name")
+        return str(legacy) if legacy else None
     return None
 
 

--- a/src/ops/health.py
+++ b/src/ops/health.py
@@ -264,12 +264,24 @@ def _check_dynamodb(
             None,
         )
 
+    key_types = {element.get("KeyType") for element in key_schema}
+    if "HASH" not in key_types or "RANGE" not in key_types:
+        LOGGER.error(
+            "Table key schema incomplete",
+            extra={"table_name": table_name, "key_schema": key_schema},
+        )
+        return (
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="Missing range key"),
+            None,
+        )
+
     sentinel = f"rc-health-{uuid.uuid4().hex}"
     item: Dict[str, Dict[str, str]] = {}
-    for element in key_schema:
+    for index, element in enumerate(key_schema):
         name = element.get("AttributeName")
         attr_type = attr_defs.get(name, "S")
-        item[name] = _ddb_attribute(attr_type, sentinel)
+        seed = f"{sentinel}-{index}"
+        item[name] = _ddb_attribute(attr_type, seed)
 
     try:
         client.put_item(TableName=table_name, Item=item)

--- a/tests/cli/test_rc_health.py
+++ b/tests/cli/test_rc_health.py
@@ -26,8 +26,9 @@ aws:
   secrets:
     jira: secret/jira
     webhook: secret/webhook
-jira:
-  issue_table_name: releasecopilot-jira
+storage:
+  dynamodb:
+    jira_issue_table: releasecopilot-jira
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/ops/test_health_checks.py
+++ b/tests/ops/test_health_checks.py
@@ -60,8 +60,14 @@ def test_run_readiness_success() -> None:
             {
                 "Table": {
                     "TableName": options.table_name,
-                    "KeySchema": [{"AttributeName": "issue_id", "KeyType": "HASH"}],
-                    "AttributeDefinitions": [{"AttributeName": "issue_id", "AttributeType": "S"}],
+                    "KeySchema": [
+                        {"AttributeName": "issue_key", "KeyType": "HASH"},
+                        {"AttributeName": "updated_at", "KeyType": "RANGE"},
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "issue_key", "AttributeType": "S"},
+                        {"AttributeName": "updated_at", "AttributeType": "S"},
+                    ],
                 }
             },
             {"TableName": options.table_name},
@@ -69,12 +75,24 @@ def test_run_readiness_success() -> None:
         ddb_stub.add_response(
             "put_item",
             {},
-            {"TableName": options.table_name, "Item": {"issue_id": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Item": {
+                    "issue_key": {"S": ANY},
+                    "updated_at": {"S": ANY},
+                },
+            },
         )
         ddb_stub.add_response(
             "delete_item",
             {},
-            {"TableName": options.table_name, "Key": {"issue_id": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Key": {
+                    "issue_key": {"S": ANY},
+                    "updated_at": {"S": ANY},
+                },
+            },
         )
 
         s3_stub.add_response(
@@ -132,8 +150,14 @@ def test_readiness_reports_secret_failure() -> None:
             {
                 "Table": {
                     "TableName": options.table_name,
-                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
-                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"},
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"},
+                    ],
                 }
             },
             {"TableName": options.table_name},
@@ -141,12 +165,24 @@ def test_readiness_reports_secret_failure() -> None:
         ddb_stub.add_response(
             "put_item",
             {},
-            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Item": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
         ddb_stub.add_response(
             "delete_item",
             {},
-            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Key": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
 
         s3_stub.add_response(
@@ -194,8 +230,14 @@ def test_webhook_missing_fails() -> None:
             {
                 "Table": {
                     "TableName": options.table_name,
-                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
-                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"},
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"},
+                    ],
                 }
             },
             {"TableName": options.table_name},
@@ -203,12 +245,24 @@ def test_webhook_missing_fails() -> None:
         ddb_stub.add_response(
             "put_item",
             {},
-            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Item": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
         ddb_stub.add_response(
             "delete_item",
             {},
-            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Key": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
 
         s3_stub.add_response(
@@ -263,8 +317,14 @@ def test_s3_cleanup_warning() -> None:
             {
                 "Table": {
                     "TableName": options.table_name,
-                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
-                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"},
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"},
+                    ],
                 }
             },
             {"TableName": options.table_name},
@@ -272,12 +332,24 @@ def test_s3_cleanup_warning() -> None:
         ddb_stub.add_response(
             "put_item",
             {},
-            {"TableName": options.table_name, "Item": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Item": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
         ddb_stub.add_response(
             "delete_item",
             {},
-            {"TableName": options.table_name, "Key": {"pk": {"S": ANY}}},
+            {
+                "TableName": options.table_name,
+                "Key": {
+                    "pk": {"S": ANY},
+                    "sk": {"S": ANY},
+                },
+            },
         )
 
         s3_stub.add_response(

--- a/tests/services/test_jira_reconciliation_job_idempotency.py
+++ b/tests/services/test_jira_reconciliation_job_idempotency.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any, Dict, List
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("TABLE_NAME", "jira-recon-test")
+    yield
+
+
+def _reload() -> Any:
+    module = "services.jira_reconciliation_job.handler"
+    if module in sys.modules:
+        importlib.reload(sys.modules[module])
+    else:
+        importlib.import_module(module)
+    return importlib.import_module(module)
+
+
+def _issue(key: str, updated: str) -> Dict[str, Any]:
+    return {
+        "id": key.replace("MOB-", "100"),
+        "key": key,
+        "fields": {
+            "updated": updated,
+            "project": {"key": "MOB"},
+            "status": {"name": "In Progress"},
+            "assignee": {"displayName": "Jane"},
+            "fixVersions": [{"name": "1.0"}],
+        },
+    }
+
+
+def test_reconciliation_skips_stale_and_marks_deletes(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _reload()
+
+    existing_items = [
+        {"issue_key": "MOB-1", "updated_at": "2024-01-02T00:00:00Z", "deleted": False},
+        {"issue_key": "MOB-2", "updated_at": "2024-01-01T00:00:00Z", "deleted": False},
+    ]
+
+    monkeypatch.setattr(handler, "_query_fix_version", lambda fix_version: existing_items)
+
+    created: List[Dict[str, Any]] = []
+    deleted: List[str] = []
+
+    def _capture_put(item: Dict[str, Any]) -> None:
+        created.append(item)
+
+    def _capture_delete(issue_key: str) -> None:
+        deleted.append(issue_key)
+
+    monkeypatch.setattr(handler, "_put_item_with_retry", _capture_put)
+    monkeypatch.setattr(handler, "_mark_deleted", _capture_delete)
+
+    issues = [
+        _issue("MOB-1", "2024-01-01T00:00:00.000+0000"),
+        _issue("MOB-3", "2024-01-04T12:00:00.000+0000"),
+    ]
+
+    result = handler._reconcile_fix_version("1.0", issues)
+
+    assert created[0]["issue_key"] == "MOB-3"
+    assert created[0]["idempotency_key"].startswith("reconciliation:MOB-3")
+    assert deleted == ["MOB-2"]
+    assert result["created"] == 1
+    assert result["deleted"] == 1
+    assert result["updated"] == 0
+    assert result["fetched"] == 2

--- a/tests/services/test_jira_sync_webhook_idempotency.py
+++ b/tests/services/test_jira_sync_webhook_idempotency.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("TABLE_NAME", "jira-webhook-test")
+    yield
+
+
+def _reload() -> Any:
+    module = "services.jira_sync_webhook.handler"
+    if module in sys.modules:
+        importlib.reload(sys.modules[module])
+    else:
+        importlib.import_module(module)
+    return importlib.import_module(module)
+
+
+def _payload(updated: str = "2024-01-01T00:00:00.000+0000", delivery: str = "delivery-1") -> Dict[str, Any]:
+    return {
+        "webhookEvent": "jira:issue_updated",
+        "deliveryId": delivery,
+        "issue": {
+            "id": "1000",
+            "key": "MOB-1",
+            "fields": {
+                "updated": updated,
+                "project": {"key": "MOB"},
+                "status": {"name": "In Progress"},
+                "assignee": {"displayName": "Jane"},
+                "fixVersions": [{"name": "1.0"}],
+            },
+        },
+    }
+
+
+def test_upsert_persists_idempotency_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _reload()
+    captured: Dict[str, Any] = {}
+
+    def _capture(item: Dict[str, Any]) -> None:
+        captured.update(item)
+
+    monkeypatch.setattr(handler, "_put_item_with_retry", _capture)
+
+    handler._handle_upsert(_payload())
+
+    assert captured["issue_key"] == "MOB-1"
+    assert captured["updated_at"].startswith("2024-01-01T00:00:00")
+    assert captured["idempotency_key"] == "delivery-1"
+    assert captured["deleted"] is False
+
+
+def test_delete_creates_tombstone_when_no_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _reload()
+    captured: Dict[str, Any] = {}
+
+    def _capture(item: Dict[str, Any]) -> None:
+        captured.update(item)
+
+    monkeypatch.setattr(handler, "_fetch_latest_issue_item", lambda key: None)
+    monkeypatch.setattr(handler, "_put_item_with_retry", _capture)
+
+    result = handler._handle_delete(_payload())
+
+    assert result["success"] is True
+    assert captured["issue_key"] == "MOB-1"
+    assert captured["deleted"] is True
+    assert captured["idempotency_key"].startswith("delivery-1")
+
+
+def test_delete_updates_existing_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _reload()
+    captured: Dict[str, Any] = {}
+
+    def _capture(action, params):
+        captured.update(params)
+        return {}
+
+    monkeypatch.setattr(handler, "_fetch_latest_issue_item", lambda key: {"updated_at": "2024-01-02T00:00:00Z"})
+    monkeypatch.setattr(handler, "_execute_with_backoff", _capture)
+
+    handler._handle_delete(_payload(delivery="delivery-2"))
+
+    assert captured["Key"] == {
+        "issue_key": "MOB-1",
+        "updated_at": "2024-01-02T00:00:00Z",
+    }
+    assert captured["ExpressionAttributeValues"][":id"].startswith("delivery-2")

--- a/tests/test_core_infra_stack.py
+++ b/tests/test_core_infra_stack.py
@@ -83,11 +83,13 @@ def test_webhook_lambda_and_api_created() -> None:
             "PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True},
             "BillingMode": "PAY_PER_REQUEST",
             "KeySchema": [
-                {"AttributeName": "issue_id", "KeyType": "HASH"},
+                {"AttributeName": "issue_key", "KeyType": "HASH"},
+                {"AttributeName": "updated_at", "KeyType": "RANGE"},
             ],
             "AttributeDefinitions": Match.array_with(
                 [
-                    Match.object_like({"AttributeName": "issue_id"}),
+                    Match.object_like({"AttributeName": "issue_key"}),
+                    Match.object_like({"AttributeName": "updated_at"}),
                     Match.object_like({"AttributeName": "fix_version"}),
                     Match.object_like({"AttributeName": "status"}),
                     Match.object_like({"AttributeName": "assignee"}),
@@ -171,3 +173,10 @@ def test_eventbridge_rule_not_created_when_disabled() -> None:
     assert len(rules) == 1
     target = rules[next(iter(rules))]["Properties"]["Targets"][0]
     assert target["Arn"]["Fn::GetAtt"][0].startswith("JiraReconciliationLambda")
+
+
+def test_table_outputs_expose_name_and_arn() -> None:
+    template = _synth_stack()
+    outputs = template.to_json().get("Outputs", {})
+    assert "JiraTableName" in outputs
+    assert "JiraTableArn" in outputs

--- a/tests/unit/test_jira_issue_store.py
+++ b/tests/unit/test_jira_issue_store.py
@@ -27,21 +27,30 @@ def test_fetch_issues_returns_issue_payloads(monkeypatch: pytest.MonkeyPatch) ->
                 "Items": [
                     {
                         "issue_id": "100",
+                        "issue_key": "ABC-1",
+                        "updated_at": "2024-05-01T12:00:00Z",
                         "issue": {"key": "ABC-1", "fields": {"summary": "First"}},
                         "deleted": False,
                     },
                     {
                         "issue_id": "101",
+                        "issue_key": "ABC-2",
+                        "updated_at": "2024-05-02T12:00:00Z",
                         "issue": {"key": "ABC-2", "fields": {"summary": "Second"}},
                         "deleted": False,
                     },
                 ],
-                "LastEvaluatedKey": {"issue_id": "101"},
+                "LastEvaluatedKey": {
+                    "issue_key": "ABC-2",
+                    "updated_at": "2024-05-02T12:00:00Z",
+                },
             },
             {
                 "Items": [
                     {
                         "issue_id": "102",
+                        "issue_key": "ABC-3",
+                        "updated_at": "2024-05-03T12:00:00Z",
                         "issue": {"key": "ABC-3", "fields": {"summary": "Third"}},
                         "deleted": False,
                     }


### PR DESCRIPTION
## Summary
- switch the Jira cache table to issue_key + updated_at keys, export the ARN, and update configuration helpers and documentation
- teach webhook ingestion, reconciliation, and the Jira store client to use composite keys with idempotency metadata and tombstones
- extend health checks and tests for the new schema while adding regression coverage for webhook/reconciliation idempotency

## Testing
- pytest -q tests/unit/test_jira_webhook_handler.py tests/unit/test_jira_reconciliation_handler.py tests/unit/test_jira_issue_store.py tests/services/test_jira_sync_webhook_idempotency.py tests/services/test_jira_reconciliation_job_idempotency.py
- pytest -q tests/ops/test_health_checks.py
- pytest -q tests/cli/test_rc_health.py
- pytest -q tests/test_core_infra_stack.py
- pytest -q tests/infra/test_core_stack.py

------
https://chatgpt.com/codex/tasks/task_e_68e178fdf5b8832fa335bff956480e9e