### PR TITLE
docs(workflow): add MOP + prompt-chaining scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/mop_subprompt.yml
+++ b/.github/ISSUE_TEMPLATE/mop_subprompt.yml
@@ -1,0 +1,16 @@
+name: MOP Sub-Prompt Request
+description: Generate a sub-prompt from an active MOP
+title: "Sub-Prompt: [PR Title] from [MOP ID]"
+labels: ["mop", "sub-prompt"]
+body:
+  - type: input
+    id: mop
+    attributes: { label: MOP file (path), placeholder: prompts/mop_wave1_security.md }
+    validations: { required: true }
+  - type: input
+    id: prtitle
+    attributes: { label: PR Title, placeholder: "[Budget/Alarms] Low-Ceiling Budget + SNS Notice" }
+    validations: { required: true }
+  - type: textarea
+    id: extras
+    attributes: { label: Notes, description: Any repo-specific details }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### MOP Digest
+- MOP: <file + version>
+- Constraints: least-priv IAM, no secrets in logs, Phoenix time; lint/mypy/pytest, ≥70% cov; docs + CHANGELOG.
+- This PR implements Sequenced PR #: <n>
+
+### Checklist
+- [ ] Lint/format, mypy
+- [ ] Tests (no live network), coverage ≥ gate
+- [ ] Docs updated (README/runbook)
+- [ ] CHANGELOG updated
+
+### Markers
+**Decision:** …
+**Note:** …
+**Action:** (Owner: …) …

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased]
+### Added
+- MOP + prompt-chaining scaffolding (`prompts/` templates, runbooks, PR template, Issue form).
+- Active MOP index in docs; README quickstart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 ### Added
 - MOP + prompt-chaining scaffolding (`prompts/` templates, runbooks, PR template, Issue form).
 - Active MOP index in docs; README quickstart.
+
+### Chore
+- Remove placeholderless f-strings flagged by ruff F541.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Releasecopilot AI automates release audits by correlating Jira stories with Bitb
 > GitHub Actions definitions with `actionlint` and publishes momentum snapshots every Monday at 14:00 UTC. Trigger it manually
 > from the **Actions** tab to generate an on-demand report.
 
+## LLM Workflow: MOP + Prompt Chaining (Quickstart)
+1. Read the active MOP: `prompts/mop_wave1_security.md`.
+2. Generate a sub-prompt for the next PR (template in `prompts/subprompt_template.md`).
+3. Run the **Critic Check** (`prompts/critic_check.md`) on the output; fix any defects.
+4. Open PR with **Decision / Note / Action** markers.
+5. After merge: add a Historian-style summary comment and update the board.
+
+See `docs/active_mops.md` for current MOPs.
+
 ## Features
 
 - Fetch Jira issues for a given fix version using OAuth 3LO tokens.

--- a/clients/secrets_manager.py
+++ b/clients/secrets_manager.py
@@ -40,7 +40,7 @@ class SecretsManager:
                     "secretsmanager", region_name=self.region_name
                 )
             except (BotoCoreError, ClientError):
-                logger.exception(f"Unable to create Secrets Manager client")
+                logger.exception("Unable to create Secrets Manager client")
                 self._client = None
         return self._client
 

--- a/docs/active_mops.md
+++ b/docs/active_mops.md
@@ -1,0 +1,4 @@
+# Active MOPs
+
+- **Wave 1: Security / Costs / Storage** — `prompts/mop_wave1_security.md` (v1.1.0, Owner: Shayne)
+  - Sequenced PRs: [Secrets] → [Budget/Alarms] → [S3 Artifact Bucket]

--- a/docs/runbooks/cost_guardrails.md
+++ b/docs/runbooks/cost_guardrails.md
@@ -1,0 +1,4 @@
+# Cost Guardrails (Budgets + Alerts)
+- Configure recipients via CDK context.
+- Manual verification: Billing → Budgets → Notifications (send test) or temporarily lower threshold.
+- Note: Budgets is account-wide; check region UX.

--- a/docs/runbooks/webhook_ingest_oncall.md
+++ b/docs/runbooks/webhook_ingest_oncall.md
@@ -1,0 +1,3 @@
+# Webhook Ingest: On-call + Replay (Seed)
+- Secret rotation via AWS SM; verify Lambda permissions (GetSecretValue) and redacted logs.
+- DLQ replay steps; confirm alarm clears; link to dashboard once created.

--- a/prompts/critic_check.md
+++ b/prompts/critic_check.md
@@ -1,0 +1,10 @@
+Act as a release reviewer against the active MOP.
+
+Verify:
+- Lint/format, mypy clean; tests pass; coverage ≥ gate.
+- Tests mock network/AWS; retries/pagination covered; edge cases included.
+- IAM least privilege; **no secrets logged**; Phoenix cron DST documented (if used).
+- Artifacts deterministic with run metadata.
+- Docs + CHANGELOG updated; PR includes Decision/Note/Action.
+
+Return PASS/FAIL with a short, actionable defect list.

--- a/prompts/mop_wave1_security.md
+++ b/prompts/mop_wave1_security.md
@@ -1,0 +1,34 @@
+---
+id: mop-wave1-security
+version: 1.1.0
+owner: Shayne
+status: active
+last_review: 2025-10-06
+---
+
+# Wave 1: Security / Costs / Storage
+
+## Purpose
+Harden the landing zone: Secrets in AWS SM with least-privilege access, low-ceiling Budgets + SNS/email alerts, and a secure S3 artifacts bucket.
+
+## Global constraints
+- Least-privilege IAM; **no secrets in logs**.
+- Phoenix time (document DST behavior when scheduling).
+- Deterministic artifacts with run metadata (timestamp, env, commit SHA).
+
+## Quality bar (all PRs)
+- Lint/format: ruff + black.
+- mypy baseline on touched modules.
+- pytest with **no live network**; ≥70% coverage with PR comment.
+- README/docs update + CHANGELOG entry.
+- PR includes **Decision / Note / Action** markers.
+
+## Sequenced PRs
+1) **[Secrets]** Create & wire SM secrets + Lambda read + smoke test + `.env.example`.
+2) **[Budget/Alarms]** Monthly cost budget with **50/80/100% ACTUAL** alerts → SNS/email; names include env; manual delivery verification documented.
+3) **[S3 Artifact Bucket]** Block-public ON, SSE-S3, lifecycle 30→IA, 90→Glacier; prefix convention documented.
+
+## Artifacts & traceability
+- Docs in `docs/` (runbooks under `docs/runbooks/`).
+- `.env.example` documents secret **names** (values only in SM).
+- CDK outputs (where applicable) surface relevant ARNs.

--- a/prompts/subprompt_budget_alarms.md
+++ b/prompts/subprompt_budget_alarms.md
@@ -1,0 +1,12 @@
+Use MOP: Wave 1 – Security/Costs/Storage.
+
+Task: Implement **[Budget/Alarms] Low-Ceiling Budget + SNS Notice** as a single PR.
+Branch: infra/billing-budget-sns
+
+Acceptance Criteria:
+- AWS Budgets with **50/80/100%** ACTUAL alerts.
+- SNS/email recipients (configurable).
+- Budget names include env.
+- Manual notification verification documented.
+
+Return the 5 outputs (plan, snippets, tests, docs, risk). Use L1 `AWS::Budgets::Budget` with 3 `NotificationsWithSubscribers`. Prefer context-driven config (e.g., `cdk.json` keys: `envName`, `budgetAmountUsd`, `budgetEmailRecipients`, `budgetSnsTopicArn`). Tests: CDK assertions confirm thresholds/subscriber types.

--- a/prompts/subprompt_template.md
+++ b/prompts/subprompt_template.md
@@ -1,0 +1,17 @@
+**Context (do not alter):** Use the active MOP. Honor constraints & quality bar (lint/format, mypy, pytest w/o network, coverage gate, docs, CHANGELOG, PR markers; least-priv IAM; no secrets in logs; Phoenix time).
+
+**Task:** Implement **[PR Title]** as a single PR.
+**Branch:** feat/<area>-<short-name>
+**Acceptance Criteria:** (copy from the MOP item verbatim)
+
+**Return these 5 outputs:**
+1) Diff-oriented plan (files; function/class signatures; CDK/IAM if applicable).
+2) Key code snippets (enough to implement).
+3) Tests (file names + specimen cases; mocks/fixtures; no live network).
+4) Docs excerpt (README and/or runbook).
+5) Risk & rollback (what to verify in CI/CloudWatch; revert path).
+
+**PR markers to include:**
+- Decision: <key choice & rationale>
+- Note: <operator tip and where to look>
+- Action: <owner + target date>

--- a/scripts/seed_labels_and_issues.sh
+++ b/scripts/seed_labels_and_issues.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Requires: GitHub CLI authenticated
+
+# Labels
+gh label create "mop" --color AADDEE --description "Master Orchestrator Prompt"
+gh label create "wave:wave1" --color D4C5F9 --description "Wave 1"
+gh label create "type:feature" --color C2E0C6 || true
+gh label create "type:bug" --color F9D0C4 || true
+gh label create "priority:P1" --color FEA3A3 || true
+
+# Seed Issues (examples)
+gh issue create -t "[Wave 1] [Secrets] Create & Wire SM" -b "Implements MOP: prompts/mop_wave1_security.md (#1)." -l "mop, wave:wave1, type:feature, priority:P1"
+gh issue create -t "[Wave 1] [Budget/Alarms] Low-Ceiling Budget + SNS Notice" -b "Implements MOP: prompts/mop_wave1_security.md (#2)." -l "mop, wave:wave1, type:feature"
+gh issue create -t "[Wave 1] [S3 Artifact Bucket]" -b "Implements MOP: prompts/mop_wave1_security.md (#3)." -l "mop, wave:wave1, type:feature"


### PR DESCRIPTION
## Summary
- add wave 1 security MOP plus reusable sub-prompt, critic, and budget follow-up templates
- seed operator runbooks, active MOP index, and README quickstart for the LLM workflow
- require PR marker compliance via templates and add optional gh helper to seed labels/issues

## Testing
- not run (docs and templates only)

PR Markers
Decision: Store MOPs under prompts/ with versioned headers; require PRs to include a MOP digest and markers.
Note: Sub-prompts always inherit the MOP quality bar (lint/mypy/tests/coverage/docs/CHANGELOG).
Action: (Owner: Shayne) Use prompts/subprompt_budget_alarms.md to generate the next PR plan today.


------
https://chatgpt.com/codex/tasks/task_e_68e43d713218832f865e4ba32db6d43b