### PR TITLE
Add monthly budget alerts with SNS and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Least-privilege Secrets Manager wiring with secret smoke test CLI and redaction helpers.
 - MOP + prompt-chaining scaffolding (`prompts/` templates, runbooks, PR template, Issue form).
 - Active MOP index in docs; README quickstart.
+- Monthly AWS Budgets cost guardrail with SNS/email alerts and manual verification runbook.
 
 ### Chore
 - Remove placeholderless f-strings flagged by ruff F541.

--- a/cdk.json
+++ b/cdk.json
@@ -10,6 +10,10 @@
     "bitbucketSecretArn": "",
     "scheduleEnabled": false,
     "scheduleCron": "cron(30 1 * * ? *)",
-    "alarmEmail": ""
+    "budgetAmount": 500,
+    "budgetCurrency": "USD",
+    "budgetEmailRecipients": "finops@example.com",
+    "budgetSnsTopicName": "",
+    "budgetExistingSnsTopicArn": ""
   }
 }

--- a/docs/runbooks/cost_guardrails.md
+++ b/docs/runbooks/cost_guardrails.md
@@ -1,4 +1,41 @@
 # Cost Guardrails (Budgets + Alerts)
-- Configure recipients via CDK context.
-- Manual verification: Billing → Budgets → Notifications (send test) or temporarily lower threshold.
-- Note: Budgets is account-wide; check region UX.
+
+The core stack provisions an AWS Budgets monthly cost budget that emits alerts
+at 50 %, 80 %, and 100 % of the configured spend limit. Alerts flow to both an
+SNS topic (forwarded to downstream automation) and direct email recipients.
+
+## Configuration
+
+- Configure the budget amount, currency, email recipients, and optional SNS
+  topic name via CDK context (`budgetAmount`, `budgetCurrency`,
+  `budgetEmailRecipients`, and `budgetSnsTopicName`).
+- To wire an existing SNS topic, set `budgetExistingSnsTopicArn` and leave the
+  name blank. The stack will skip topic creation and reuse the provided ARN.
+- Stack names incorporate the deployment environment (for example,
+  `releasecopilot-dev-monthly-cost`) to keep multi-environment budgets
+  disambiguated.
+
+## Manual Verification (Phoenix Time)
+
+1. Deploy the stack and capture the `BudgetAlertsTopicArn` output from the CDK
+   synthesis or deployment logs. Store it with the release metadata so future
+   runs stay deterministic.
+2. In the AWS console, open **Billing → Budgets → Cost budgets** and confirm the
+   `releasecopilot-<env>-monthly-cost` entry shows three ACTUAL alert thresholds
+   (50 %, 80 %, 100 %).
+3. Select the budget and choose **Actions → Edit notifications**. Use **Send
+   test email/SNS notification** for each subscriber. AWS Budgets operates on a
+   Phoenix-time basis: production alerts can take up to 8 hours to arrive, so
+   rely on the manual test button instead of forcing spend.
+4. For SNS delivery, publish a test message to the topic via the console while
+   observing the downstream subscription endpoints (for example, Slack or
+   ticketing integrations). Document the timestamp of the successful delivery
+   in the release record.
+
+## Troubleshooting
+
+- If manual notifications fail, confirm the SNS topic allows the
+  `budgets.amazonaws.com` service principal to publish. The generated topic
+  includes this policy; legacy topics may need a manual update.
+- Budgets are global to the AWS account. The console defaults to `us-east-1`,
+  but alerts remain account-wide regardless of the UI region selector.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -17,3 +17,19 @@ so that webhook replays remain idempotent. Global secondary indexes for
 `FixVersionIndex`, `StatusIndex`, and `AssigneeIndex` are unchanged. Stack
 outputs expose both the table name (`JiraTableName`) and ARN (`JiraTableArn`)
 so IAM deploy roles can scope DynamoDB permissions precisely.
+
+## Budget Alerts Configuration
+
+The stack also manages a monthly AWS Budgets cost guardrail with SNS and email
+notifications. Configure it through CDK context values:
+
+| Context key | Purpose |
+| --- | --- |
+| `budgetAmount` | Monthly spend limit (float). |
+| `budgetCurrency` | ISO currency code (defaults to `USD`). |
+| `budgetEmailRecipients` | Comma-separated email recipients. |
+| `budgetSnsTopicName` | Optional explicit SNS topic name (leave blank for generated). |
+| `budgetExistingSnsTopicArn` | Reuse an existing SNS topic ARN instead of creating one. |
+
+Deployments output `BudgetAlertsTopicArn`; persist it with run metadata to keep
+alert routing deterministic across environments.

--- a/infra/cdk/app.py
+++ b/infra/cdk/app.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 import aws_cdk as cdk
 from cdk_nag import AwsSolutionsChecks, NagSuppressions
@@ -32,6 +32,19 @@ def _to_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _csv_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        items = value
+    else:
+        text = str(value).strip()
+        if not text:
+            return []
+        items = (item.strip() for item in text.split(","))
+    return [item for item in items if item]
+
+
 def _load_context(app: cdk.App) -> Dict[str, Any]:
     return {
         "env": str(_context(app, "env", "dev")),
@@ -47,16 +60,33 @@ def _load_context(app: cdk.App) -> Dict[str, Any]:
         "lambdaTimeoutSec": int(_context(app, "lambdaTimeoutSec", 180)),
         "lambdaMemoryMb": int(_context(app, "lambdaMemoryMb", 512)),
         "jiraWebhookSecretArn": str(_context(app, "jiraWebhookSecretArn", "")),
-        "jiraBaseUrl": str(_context(app, "jiraBaseUrl", "https://your-domain.atlassian.net")),
+        "jiraBaseUrl": str(
+            _context(app, "jiraBaseUrl", "https://your-domain.atlassian.net")
+        ),
         "reconciliationCron": str(_context(app, "reconciliationCron", "")),
-        "reconciliationFixVersions": str(_context(app, "reconciliationFixVersions", "")),
+        "reconciliationFixVersions": str(
+            _context(app, "reconciliationFixVersions", "")
+        ),
         "reconciliationJqlTemplate": str(
-            _context(app, "reconciliationJqlTemplate", "fixVersion = '{fix_version}' ORDER BY key")
+            _context(
+                app,
+                "reconciliationJqlTemplate",
+                "fixVersion = '{fix_version}' ORDER BY key",
+            )
         ),
         "reconciliationScheduleEnabled": _to_bool(
             _context(app, "reconciliationScheduleEnabled", True)
         ),
-        "metricsNamespace": str(_context(app, "metricsNamespace", "ReleaseCopilot/JiraSync")),
+        "metricsNamespace": str(
+            _context(app, "metricsNamespace", "ReleaseCopilot/JiraSync")
+        ),
+        "budgetAmount": float(_context(app, "budgetAmount", 500)),
+        "budgetCurrency": str(_context(app, "budgetCurrency", "USD")),
+        "budgetEmailRecipients": _csv_list(_context(app, "budgetEmailRecipients", "")),
+        "budgetSnsTopicName": str(_context(app, "budgetSnsTopicName", "")),
+        "budgetExistingSnsTopicArn": str(
+            _context(app, "budgetExistingSnsTopicArn", "")
+        ),
     }
 
 
@@ -82,7 +112,9 @@ def _aws_identity(region_hint: Optional[str]) -> Tuple[Optional[str], Optional[s
     return identity.get("Account"), resolved_region
 
 
-def _resolve_environment(app: cdk.App, context: Dict[str, Any]) -> Tuple[Optional[str], str]:
+def _resolve_environment(
+    app: cdk.App, context: Dict[str, Any]
+) -> Tuple[Optional[str], str]:
     account = _optional_str(context.get("account"))
     region = _optional_str(context.get("region"))
 
@@ -154,6 +186,12 @@ core_stack = CoreStack(
     reconciliation_jql_template=context["reconciliationJqlTemplate"] or None,
     jira_base_url=context["jiraBaseUrl"] or None,
     metrics_namespace=context["metricsNamespace"] or None,
+    environment_name=context["env"],
+    budget_amount=context["budgetAmount"],
+    budget_currency=context["budgetCurrency"],
+    budget_email_recipients=context["budgetEmailRecipients"],
+    budget_sns_topic_name=context["budgetSnsTopicName"] or None,
+    budget_existing_sns_topic_arn=context["budgetExistingSnsTopicArn"] or None,
 )
 
 NagSuppressions.add_stack_suppressions(

--- a/infra/cdk/constructs/__init__.py
+++ b/infra/cdk/constructs/__init__.py
@@ -1,5 +1,6 @@
 """Reusable CDK constructs for ReleaseCopilot infrastructure."""
 
+from .budget_alerts import BudgetAlerts
 from .secret_access import SecretAccess, SecretGrant
 
-__all__ = ["SecretAccess", "SecretGrant"]
+__all__ = ["BudgetAlerts", "SecretAccess", "SecretGrant"]

--- a/infra/cdk/constructs/budget_alerts.py
+++ b/infra/cdk/constructs/budget_alerts.py
@@ -1,0 +1,127 @@
+"""Budget alert construct for ReleaseCopilot cost guardrails."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from aws_cdk import aws_budgets as budgets, aws_iam as iam, aws_sns as sns
+from constructs import Construct
+
+
+class BudgetAlerts(Construct):
+    """Provision a monthly cost budget with SNS and email notifications."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        environment_name: str,
+        budget_amount: float,
+        currency: str = "USD",
+        email_recipients: Sequence[str] | None = None,
+        sns_topic_name: str | None = None,
+        existing_topic_arn: str | None = None,
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        if budget_amount <= 0:
+            raise ValueError("budget_amount must be positive")
+
+        self.environment_name = environment_name
+        self.budget_amount = budget_amount
+        self.currency = currency
+
+        normalized_env = environment_name.replace(" ", "-").lower()
+        topic_id = "BudgetAlertsTopic"
+
+        if existing_topic_arn:
+            self.topic = sns.Topic.from_topic_arn(self, topic_id, existing_topic_arn)
+            topic_arn = existing_topic_arn
+            can_add_policy = False
+        else:
+            topic = sns.Topic(
+                self,
+                topic_id,
+                display_name=f"ReleaseCopilot {environment_name} Budget Alerts",
+                topic_name=sns_topic_name
+                or f"releasecopilot-{normalized_env}-budget-alerts",
+            )
+            topic.add_to_resource_policy(
+                iam.PolicyStatement(
+                    sid="AllowBudgetsPublish",
+                    actions=["SNS:Publish"],
+                    effect=iam.Effect.ALLOW,
+                    principals=[iam.ServicePrincipal("budgets.amazonaws.com")],
+                    resources=[topic.topic_arn],
+                )
+            )
+            self.topic = topic
+            topic_arn = topic.topic_arn
+            can_add_policy = True
+
+        subscribers = [
+            budgets.CfnBudget.SubscriberProperty(
+                subscription_type="SNS",
+                address=topic_arn,
+            )
+        ]
+
+        for email in _sanitize_emails(email_recipients):
+            subscribers.append(
+                budgets.CfnBudget.SubscriberProperty(
+                    subscription_type="EMAIL",
+                    address=email,
+                )
+            )
+
+        notifications = [
+            budgets.CfnBudget.NotificationWithSubscribersProperty(
+                notification=budgets.CfnBudget.NotificationProperty(
+                    comparison_operator="GREATER_THAN",
+                    notification_type="ACTUAL",
+                    threshold=threshold,
+                    threshold_type="PERCENTAGE",
+                ),
+                subscribers=list(subscribers),
+            )
+            for threshold in (50, 80, 100)
+        ]
+
+        budget_name = f"releasecopilot-{normalized_env}-monthly-cost"
+
+        self.budget = budgets.CfnBudget(
+            self,
+            "MonthlyCostBudget",
+            budget=budgets.CfnBudget.BudgetDataProperty(
+                budget_name=budget_name,
+                budget_limit=budgets.CfnBudget.SpendProperty(
+                    amount=budget_amount,
+                    unit=currency,
+                ),
+                budget_type="COST",
+                time_unit="MONTHLY",
+            ),
+            notifications_with_subscribers=notifications,
+        )
+
+        if can_add_policy:
+            self.budget.node.add_dependency(self.topic)
+
+    @property
+    def sns_topic(self) -> sns.ITopic:
+        """Expose the budget alert topic for stack integrations."""
+
+        return self.topic
+
+
+def _sanitize_emails(recipients: Iterable[str] | None) -> list[str]:
+    if not recipients:
+        return []
+    sanitized: list[str] = []
+    for email in recipients:
+        trimmed = email.strip()
+        if not trimmed:
+            continue
+        sanitized.append(trimmed)
+    return sanitized

--- a/tests/infra/test_budget_alerts.py
+++ b/tests/infra/test_budget_alerts.py
@@ -1,0 +1,108 @@
+"""Tests covering the budget alert wiring for the core stack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aws_cdk import App, Environment
+from aws_cdk.assertions import Match, Template
+
+from infra.cdk.core_stack import CoreStack
+
+
+ACCOUNT = "123456789012"
+REGION = "us-west-2"
+ASSET_DIR = str(Path(__file__).resolve().parents[2] / "dist")
+
+
+def _synth_template(**overrides) -> Template:
+    app = App()
+    stack = CoreStack(
+        app,
+        "TestBudgetStack",
+        env=Environment(account=ACCOUNT, region=REGION),
+        bucket_name=f"releasecopilot-artifacts-{ACCOUNT}",
+        lambda_asset_path=ASSET_DIR,
+        environment_name=overrides.pop("environment_name", "dev"),
+        budget_amount=overrides.pop("budget_amount", 275.0),
+        budget_currency=overrides.pop("budget_currency", "USD"),
+        budget_email_recipients=overrides.pop(
+            "budget_email_recipients", ["alerts@example.com"]
+        ),
+        **overrides,
+    )
+    return Template.from_stack(stack)
+
+
+def test_budget_notifications_configured() -> None:
+    template = _synth_template()
+
+    template.resource_count_is("AWS::Budgets::Budget", 1)
+    template.resource_count_is("AWS::SNS::Topic", 1)
+
+    budget = next(iter(template.find_resources("AWS::Budgets::Budget").values()))
+
+    assert (
+        budget["Properties"]["Budget"]["BudgetName"]
+        == "releasecopilot-dev-monthly-cost"
+    )
+
+    notifications = budget["Properties"]["NotificationsWithSubscribers"]
+    assert len(notifications) == 3
+    assert {entry["Notification"]["Threshold"] for entry in notifications} == {
+        50,
+        80,
+        100,
+    }
+
+    template.has_resource_properties(
+        "AWS::Budgets::Budget",
+        Match.object_like(
+            {
+                "Budget": Match.object_like(
+                    {
+                        "BudgetLimit": {"Amount": 275.0, "Unit": "USD"},
+                        "BudgetType": "COST",
+                        "TimeUnit": "MONTHLY",
+                    }
+                ),
+                "NotificationsWithSubscribers": Match.array_with(
+                    [
+                        Match.object_like(
+                            {
+                                "Notification": Match.object_like(
+                                    {
+                                        "ComparisonOperator": "GREATER_THAN",
+                                        "NotificationType": "ACTUAL",
+                                        "ThresholdType": "PERCENTAGE",
+                                    }
+                                ),
+                                "Subscribers": Match.array_with(
+                                    [
+                                        Match.object_like({"SubscriptionType": "SNS"}),
+                                        Match.object_like(
+                                            {
+                                                "SubscriptionType": "EMAIL",
+                                                "Address": "alerts@example.com",
+                                            }
+                                        ),
+                                    ]
+                                ),
+                            }
+                        )
+                    ]
+                ),
+            }
+        ),
+    )
+
+
+def test_budget_topic_arn_output_present() -> None:
+    template = _synth_template(
+        budget_email_recipients=["finops@example.com"],
+        environment_name="prod",
+    )
+
+    outputs = template.to_json().get("Outputs", {})
+    assert "BudgetAlertsTopicArn" in outputs
+    assert "Topic" in outputs["BudgetAlertsTopicArn"]["Value"]["Ref"]


### PR DESCRIPTION
## Summary
- add a reusable `BudgetAlerts` construct and wire it into the core stack with an SNS topic output
- extend the CDK app context to accept budget configuration and update docs/runbooks for cost guardrails
- cover the budget flow with dedicated assertions and adjust existing stack tests for the extra topic

## Testing
- `ruff check infra/cdk tests/infra`
- `black infra/cdk/app.py infra/cdk/core_stack.py infra/cdk/constructs/budget_alerts.py tests/infra/test_budget_alerts.py tests/infra/test_core_stack.py`
- `mypy --follow-imports=skip infra/cdk/app.py`
- `mypy --follow-imports=skip infra/cdk/core_stack.py`
- `mypy --follow-imports=skip infra/cdk/constructs/budget_alerts.py`
- `pytest`

**Decision:** Keep the budget wiring isolated in a construct so the core stack can emit a deterministic topic ARN while satisfying least-privilege SNS policies.
**Note:** Operators can confirm alerts via the Billing → Budgets console using the send-test buttons described in the cost guardrails runbook.
**Action:** FinOps to record the first production SNS receipt in the deployment log before 2025-10-31.

------
https://chatgpt.com/codex/tasks/task_e_68e5b70d811c832f9c4c3c3b439251fb