### PR TITLE
fix: enforce TLS for BudgetAlerts SNS topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@
   in the synthesized template, matching the Wave 1 least-privilege contract.
 - Restore the ``AllowSecretRetrieval`` Sid with explicit secret ARNs while
   keeping the inline policy confined to four least-privilege statements.
+- Enforce TLS-only publishing on the BudgetAlerts SNS topic to resolve
+  AwsSolutions-SNS3.

--- a/docs/runbooks/budget-alerts.md
+++ b/docs/runbooks/budget-alerts.md
@@ -1,0 +1,23 @@
+# Budget Alerts Runbook
+
+## Overview
+Budget alerts notify the team when AWS spending crosses defined thresholds for the current month.
+
+## TLS-only publishing
+The `BudgetAlerts` SNS topic enforces TLS for all publishers. Any publish request that is not sent with secure transport (`aws:SecureTransport=false`) is denied by the resource policy. Use HTTPS/TLS clients when integrating with the topic.
+
+## Operations
+- Deploy or update the infrastructure with `cdk deploy`.
+- Capture the `BudgetAlertsTopicArn` output and store it with the deployment metadata.
+- After deployment, publish a test message using an HTTPS client to confirm the policy allows TLS publishers.
+
+## Incident response
+1. Review CloudWatch metrics and alarms related to cost budgets.
+2. If alerts are missing, verify that publishers are using TLS when sending messages.
+3. Re-deploy the stack if policy drift is detected.
+
+## Rollback
+If a legitimate publisher cannot use TLS, revert the policy statement commit and redeploy the stack. Document any exceptions and work with the publisher to restore secure transport.
+
+## Time zone
+Unless otherwise noted, times are tracked in America/Phoenix.

--- a/infra/cdk/constructs/budget_alerts.py
+++ b/infra/cdk/constructs/budget_alerts.py
@@ -56,6 +56,16 @@ class BudgetAlerts(Construct):
                     resources=[topic.topic_arn],
                 )
             )
+            topic.add_to_resource_policy(
+                iam.PolicyStatement(
+                    sid="DenyPublishWithoutTLS",
+                    actions=["sns:Publish"],
+                    effect=iam.Effect.DENY,
+                    principals=[iam.AnyPrincipal()],
+                    resources=[topic.topic_arn],
+                    conditions={"Bool": {"aws:SecureTransport": "false"}},
+                )
+            )
             self.topic = topic
             topic_arn = topic.topic_arn
             can_add_policy = True

--- a/tests/infra/test_budget_alerts_topic.py
+++ b/tests/infra/test_budget_alerts_topic.py
@@ -1,0 +1,52 @@
+"""Validate the BudgetAlerts topic resource policy."""
+
+from aws_cdk import App, Stack
+from aws_cdk.assertions import Template
+
+from infra.cdk.constructs.budget_alerts import BudgetAlerts
+
+
+def _synthesize_template() -> dict:
+    app = App()
+    stack = Stack(app, "TestStack")
+    BudgetAlerts(stack, "TestBudgetAlerts", environment_name="Dev", budget_amount=100)
+    template = Template.from_stack(stack).to_json()
+    return template
+
+
+def test_budget_alerts_topic_denies_non_tls_publish() -> None:
+    template = _synthesize_template()
+
+    deny_statements = []
+    for resource in template["Resources"].values():
+        if resource.get("Type") != "AWS::SNS::TopicPolicy":
+            continue
+        for statement in resource["Properties"]["PolicyDocument"]["Statement"]:
+            if statement.get("Sid") == "DenyPublishWithoutTLS":
+                deny_statements.append(statement)
+
+    assert len(deny_statements) == 1
+
+    deny = deny_statements[0]
+    assert deny["Effect"] == "Deny"
+    actions = deny["Action"]
+    if isinstance(actions, str):
+        actions = [actions]
+    assert "sns:Publish" in actions
+    assert deny["Condition"]["Bool"]["aws:SecureTransport"] == "false"
+    assert deny["Principal"] in ("*", {"AWS": "*"})
+
+
+def test_budget_alerts_topic_policy_has_single_tls_statement() -> None:
+    template = _synthesize_template()
+
+    statements = []
+    for resource in template["Resources"].values():
+        if resource.get("Type") != "AWS::SNS::TopicPolicy":
+            continue
+        statements.extend(resource["Properties"]["PolicyDocument"]["Statement"])
+
+    sid_count = sum(
+        1 for statement in statements if statement.get("Sid") == "DenyPublishWithoutTLS"
+    )
+    assert sid_count == 1


### PR DESCRIPTION
## Summary
- deny non-TLS `sns:Publish` attempts on the BudgetAlerts topic so AwsSolutions-SNS3 passes
- add coverage ensuring the TLS-only policy is synthesized exactly once
- document TLS-only publishing for BudgetAlerts and record the fix in the changelog

## Testing
- `ruff check infra/cdk tests/infra`
- `black --check infra/cdk/constructs/budget_alerts.py tests/infra/test_budget_alerts_topic.py`
- `python -m mypy infra/cdk/constructs/budget_alerts.py tests/infra/test_budget_alerts_topic.py`
- `pytest tests/infra/test_budget_alerts_topic.py`
- `npx cdk synth`

Blocker: CI failing on AwsSolutions-SNS3 blocked Wave 1 – PR #269 .
Decision: Enforce TLS-only via deny on aws:SecureTransport=false.
Note: Stable SID; tests offline; Phoenix TZ documented.
Action: Implement policy + tests; update docs/CHANGELOG; re-run CI; Closes #270.
Closes #270

------
https://chatgpt.com/codex/tasks/task_e_68e6e5ea5c58832fbdd6f676322f988d