### PR TITLE
Wave 3: enforce Decision/Note/Action template and Phoenix orchestrator docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,11 +3,17 @@
 - Constraints: least-priv IAM, no secrets in logs, Phoenix time; lint/mypy/pytest, ≥70% cov; docs + CHANGELOG.
 - This PR implements Sequenced PR #: <n>
 
-### Checklist
-- [ ] Lint/format, mypy
-- [ ] Tests (no live network), coverage ≥ gate
-- [ ] Docs updated (README/runbook)
-- [ ] CHANGELOG updated
+### Decision / Note / Action
+**Decision:** <!-- Summarize the go/no-go outcome and link to the manifest entry -->
+**Note:** <!-- Highlight caveats, Phoenix-aware scheduling callouts, or reviewer context -->
+**Action:** <!-- Enumerate follow-ups or owners for downstream tasks -->
+
+### Quality Gates
+- [ ] Tests updated and ≥70% coverage on touched code (`pytest --cov` or equivalent).
+- [ ] `ruff` lint passes with no new warnings.
+- [ ] `black` formatting applied or `black --check` passes.
+- [ ] `mypy` type checks pass for touched modules.
+- [ ] Docs updated (README/runbook) and CHANGELOG entries applied when required.
 
 ### Markers
 <!-- Use canonical Decision:/Note:/Action:/Blocker: prefixes in the PR body -->

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ pre-commit run --all-files
 
 The pre-commit hooks run `ruff --fix`, `black`, and `mypy` locally, catching formatting drifts before `black --check .` executes in CI.
 
+## Contributing & Quality Gates
+
+- Pull request descriptions must begin with **Decision:**, **Note:**, and **Action:** summaries that align with the generated manifest entry and reference Phoenix (America/Phoenix) scheduling where applicable.
+- Confirm ≥70% test coverage on touched code by running `pytest --cov` (or an equivalent target) and link to the report when requesting review.
+- Acknowledge the lint/type gates explicitly by running `ruff`, `black`, and `mypy` before submitting the PR template checklist.
+- Document updates belong alongside code changes; orchestrator-related pull requests should cross-reference [`docs/runbooks/orchestrator.md`](docs/runbooks/orchestrator.md) so reviewers can validate Phoenix-aware plan and dispatch flows.
+- Phoenix time (America/Phoenix, UTC-7 year-round) is the canonical timezone for orchestration—include Phoenix-local timestamps in new artifacts and note deviations in the **Note:** section of the PR template.
+
 ## Generating Waves (YAML → MOP/Sub-Prompts/Issues)
 
 Wave 3 and later waves are defined in YAML (`backlog/wave3.yaml`). The helper CLI renders the Mission Outline Plan (MOP), sub-prompts, issue bodies, and a JSON manifest directly from that spec.

--- a/docs/runbooks/orchestrator.md
+++ b/docs/runbooks/orchestrator.md
@@ -1,0 +1,47 @@
+# Orchestrator Operations (America/Phoenix)
+
+Phoenix (America/Phoenix) remains the canonical timezone for planning, dispatching, and auditing orchestrator workflows. The timezone does not observe daylight saving time, so all scheduling references should anchor to Mountain Standard Time (UTC-7) year-round. When converting timestamps, prefer explicit offsets and include Phoenix-local copies in manifests and chat summaries.
+
+## Slash-command overview
+
+ChatOps users can manage orchestrator timelines through the following slash-commands. Always validate that the rendered timestamps reflect America/Phoenix unless a manifest explicitly authorizes a different timezone.
+
+### `rc orchestrator plan`
+
+Generate or refresh a mission outline plan:
+
+```bash
+rc orchestrator plan \
+  --wave 3 \
+  --timezone America/Phoenix \
+  --output artifacts/orchestrator/plan.json
+```
+
+- Produces Phoenix-aware milestones with Decision / Note / Action markers for each checkpoint.
+- Stores the artifact under `artifacts/orchestrator/` so reviewers can link it in pull requests.
+- Supports `--at "2025-04-18T09:00:00"` when you need to regenerate a plan effective at a specific Phoenix-local timestamp.
+
+### `rc orchestrator dispatch`
+
+Execute previously generated plans without recomputing schedules:
+
+```bash
+rc orchestrator dispatch \
+  --plan artifacts/orchestrator/plan.json \
+  --timezone America/Phoenix
+```
+
+- Reuses the Phoenix timestamps embedded in the plan file to avoid DST drift.
+- Emits Decision / Note / Action markers for every dispatched task to maintain traceability.
+- Accepts `--dry-run` to preview the Phoenix schedule without triggering downstream hooks.
+
+## Phoenix-aware scheduling tips
+
+- Always confirm the orchestrator command output contains the `America/Phoenix` label before sharing or committing artifacts.
+- When cross-functional teams require other timezones, duplicate the Phoenix schedule and include both references in documentation instead of replacing the canonical timezone.
+- Update the plan artifact immediately after any Decision or Action changes so dispatch inherits the correct Phoenix timestamp windows.
+
+## Related runbooks
+
+- [`docs/runbooks/orchestrator_dispatch.md`](orchestrator_dispatch.md) – legacy dispatcher procedures; defer to this page for slash-command usage.
+- [`docs/promptops/human_actions.md`](../promptops/human_actions.md) – human-in-the-loop orchestration expectations tied to Phoenix checkpoints.


### PR DESCRIPTION
### Summary
* require Decision/Note/Action summaries and explicit quality gate acknowledgements in the PR template
* document Phoenix-aware orchestrator plan/dispatch slash commands and link them from the README contributing guidance

### Testing
* not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68f183680ca4832fadeb041d148763c3