### PR TITLE
Harden CI linting, typing, and coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Pre-commit (ruff, black, mypy)
-        run: scripts/ci/run_precommit.sh
-        shell: bash
+      - name: Ruff
+        run: ruff check .
+
+      - name: Black
+        run: black --check .
+
+      - name: Mypy
+        run: mypy --config-file mypy.ini -p releasecopilot
 
       - name: Pytest
-        run: pytest -q
+        run: pytest --cov=src --cov-report=xml
+
+      - name: Coverage gate
+        run: scripts/ci/coverage_gate.py coverage.xml
 
   package:
     name: Package Lambda bundle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,7 @@ repos:
         entry: make check-generated
         language: system
         pass_filenames: false
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased]
+### Hardened CI Quality Gate
+**Decision:** Enforce linting, formatting, typing, and coverage thresholds directly in CI with Phoenix-aligned guidance for contributors.
+**Note:** Local and CI runs now share the `ruff check .`, `black --check .`, `mypy --config-file mypy.ini`, and `pytest --cov=src` sequence with America/Phoenix (UTC-7) timeboxing.
+**Action:** Added tooling configuration in `pyproject.toml`, centralized network/config stubs in `tests/conftest.py`, hardened `.github/workflows/ci.yml` with explicit lint/type/coverage steps, surfaced coverage summaries via `scripts/ci/coverage_gate.py`, and refreshed README/runbook guidance.
 ### Wave 3 Onboarding and Validation
 **Decision:** Document Wave 3 generator onboarding so contributors can translate `backlog/wave3.yaml` into sub-prompts deterministically.
 **Note:** America/Phoenix (UTC-7, no DST) remains the required timezone for manifests, archives, and coverage checks.

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 import os
 
 import aws_cdk as cdk
-
 from stacks.core_stack import CoreStack
 from stacks.lambda_stack import LambdaStack
-
 
 app = cdk.App()
 project = app.node.try_get_context("projectName") or "releasecopilot-ai"

--- a/cdk/stacks/core_stack.py
+++ b/cdk/stacks/core_stack.py
@@ -6,8 +6,14 @@ from aws_cdk import (
     CfnOutput,
     RemovalPolicy,
     Stack,
+)
+from aws_cdk import (
     aws_iam as iam,
+)
+from aws_cdk import (
     aws_s3 as s3,
+)
+from aws_cdk import (
     aws_secretsmanager as secretsmanager,
 )
 from constructs import Construct
@@ -16,9 +22,7 @@ from constructs import Construct
 class CoreStack(Stack):
     """Provision foundational resources shared by compute workloads."""
 
-    def __init__(
-        self, scope: Construct, construct_id: str, *, project_name: str, **kwargs
-    ) -> None:
+    def __init__(self, scope: Construct, construct_id: str, *, project_name: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         self.artifacts_bucket = s3.Bucket(

--- a/cdk/stacks/lambda_stack.py
+++ b/cdk/stacks/lambda_stack.py
@@ -7,9 +7,17 @@ from pathlib import Path
 from aws_cdk import (
     Duration,
     Stack,
+)
+from aws_cdk import (
     aws_events as events,
+)
+from aws_cdk import (
     aws_events_targets as targets,
+)
+from aws_cdk import (
     aws_iam as iam,
+)
+from aws_cdk import (
     aws_lambda as _lambda,
 )
 from constructs import Construct

--- a/clients/base.py
+++ b/clients/base.py
@@ -28,9 +28,7 @@ class BaseAPIClient:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self._last_cache_files: dict[str, Path] = {}
         self._random = random.Random()
-        self._retries_enabled = os.getenv(
-            "RC_DISABLE_RETRIES", "false"
-        ).lower() not in {
+        self._retries_enabled = os.getenv("RC_DISABLE_RETRIES", "false").lower() not in {
             "1",
             "true",
             "yes",
@@ -83,9 +81,7 @@ class BaseAPIClient:
         if isinstance(exc, retryable):
             return True
         response = getattr(exc, "response", None)
-        if response is not None and BaseAPIClient._is_retryable_status(
-            response.status_code
-        ):
+        if response is not None and BaseAPIClient._is_retryable_status(response.status_code):
             return True
         return False
 
@@ -146,10 +142,7 @@ class BaseAPIClient:
                 response_context["rate_limit"] = headers
             logger.debug("HTTP response", extra=response_context)
 
-            if (
-                self._is_retryable_status(response.status_code)
-                and attempt < max_attempts
-            ):
+            if self._is_retryable_status(response.status_code) and attempt < max_attempts:
                 delay = self._compute_delay(attempt, response)
                 retry_context = dict(response_context)
                 retry_context["retry_in_s"] = round(delay, 2)

--- a/clients/bitbucket_client.py
+++ b/clients/bitbucket_client.py
@@ -75,9 +75,7 @@ class BitbucketClient(BaseAPIClient):
                     commits = self._fetch_commits_for_branch(repo, branch, start, end)
                 except BitbucketRequestError:
                     raise
-                except (
-                    requests.RequestException
-                ) as exc:  # pragma: no cover - defensive guard
+                except requests.RequestException as exc:  # pragma: no cover - defensive guard
                     context = {
                         "service": "bitbucket",
                         "repository": repo,

--- a/clients/jira_client.py
+++ b/clients/jira_client.py
@@ -74,9 +74,7 @@ class JiraClient(BaseAPIClient):
             context = {
                 "service": "jira",
                 "operation": "refresh_token",
-                "status_code": getattr(
-                    getattr(exc, "response", None), "status_code", None
-                ),
+                "status_code": getattr(getattr(exc, "response", None), "status_code", None),
             }
             logger.error("Failed to refresh Jira OAuth token", extra=context)
             raise JiraTokenRefreshError(
@@ -151,9 +149,7 @@ class JiraClient(BaseAPIClient):
                 )
                 response.raise_for_status()
             except requests.RequestException as exc:
-                status_code = getattr(
-                    getattr(exc, "response", None), "status_code", None
-                )
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
                 snippet = None
                 if getattr(exc, "response", None) is not None:
                     snippet = exc.response.text[:200]
@@ -166,16 +162,12 @@ class JiraClient(BaseAPIClient):
                     "snippet": snippet,
                 }
                 logger.error("Jira search failed", extra=context)
-                raise JiraQueryError(
-                    "Failed to fetch Jira issues", context=context
-                ) from exc
+                raise JiraQueryError("Failed to fetch Jira issues", context=context) from exc
             payload = response.json()
 
             batch = payload.get("issues", [])
             issues.extend(batch)
-            if len(batch) == 0 or start_at + params["maxResults"] >= payload.get(
-                "total", 0
-            ):
+            if len(batch) == 0 or start_at + params["maxResults"] >= payload.get("total", 0):
                 break
             start_at += params["maxResults"]
 
@@ -188,9 +180,7 @@ class JiraClient(BaseAPIClient):
         return issues, cache_path
 
 
-def compute_fix_version_window(
-    freeze_date: datetime, window_days: int
-) -> Dict[str, datetime]:
+def compute_fix_version_window(freeze_date: datetime, window_days: int) -> Dict[str, datetime]:
     """Helper used by downstream processing to expose the audit window."""
     return {
         "start": freeze_date - timedelta(days=window_days),

--- a/clients/jira_store.py
+++ b/clients/jira_store.py
@@ -15,7 +15,6 @@ from botocore.exceptions import ClientError
 from releasecopilot.errors import JiraQueryError
 from releasecopilot.logging_config import get_logger
 
-
 logger = get_logger(__name__)
 
 
@@ -29,12 +28,7 @@ _RETRYABLE_DDB_ERRORS = {
 
 
 def _utcnow() -> str:
-    return (
-        datetime.utcnow()
-        .replace(tzinfo=timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 @dataclass
@@ -87,12 +81,8 @@ class JiraIssueStore:
                 "fix_version": fix_version,
                 "error": str(exc),
             }
-            logger.exception(
-                "Unexpected error querying Jira issue table", extra=context
-            )
-            raise JiraQueryError(
-                "Failed to query Jira issue store", context=context
-            ) from exc
+            logger.exception("Unexpected error querying Jira issue table", extra=context)
+            raise JiraQueryError("Failed to query Jira issue store", context=context) from exc
 
         issues: List[Dict[str, Any]] = []
         seen_issue_keys: set[str] = set()
@@ -125,9 +115,7 @@ class JiraIssueStore:
     # Internal helpers -----------------------------------------------
     def _paginate_query(self, *, fix_version: str) -> Iterable[Dict[str, Any]]:
         if not fix_version:
-            logger.warning(
-                "Empty fix version provided to JiraIssueStore; returning no items"
-            )
+            logger.warning("Empty fix version provided to JiraIssueStore; returning no items")
             return []
 
         params: Dict[str, Any] = {
@@ -189,9 +177,7 @@ class JiraIssueStore:
             "captured_at": _utcnow(),
         }
         logger.error("DynamoDB query failed", extra=context)
-        raise JiraQueryError(
-            "Failed to query Jira issue store", context=context
-        ) from error
+        raise JiraQueryError("Failed to query Jira issue store", context=context) from error
 
 
 __all__ = ["JiraIssueStore"]

--- a/clients/secrets_manager.py
+++ b/clients/secrets_manager.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
+
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
@@ -36,9 +37,7 @@ class SecretsManager:
     def _get_client(self):
         if self._client is None and self.region_name:
             try:
-                self._client = boto3.client(
-                    "secretsmanager", region_name=self.region_name
-                )
+                self._client = boto3.client("secretsmanager", region_name=self.region_name)
             except (BotoCoreError, ClientError):
                 logger.exception("Unable to create Secrets Manager client")
                 self._client = None
@@ -51,9 +50,7 @@ class SecretsManager:
 
         client = self._get_client()
         if client is None:
-            logger.info(
-                "Secrets Manager client unavailable; skipping fetch for %s", secret_id
-            )
+            logger.info("Secrets Manager client unavailable; skipping fetch for %s", secret_id)
             return None
 
         try:

--- a/config/settings.py
+++ b/config/settings.py
@@ -23,9 +23,7 @@ def load_settings(
 
     override_path = Path(path) if path else DEFAULT_OVERRIDE_PATH
     if path and not override_path.exists():
-        logger.warning(
-            "Configuration override file %s not found; falling back to defaults", path
-        )
+        logger.warning("Configuration override file %s not found; falling back to defaults", path)
     return load_config(
         overrides=overrides,
         env=env,

--- a/docs/runbooks/contributing.md
+++ b/docs/runbooks/contributing.md
@@ -23,7 +23,13 @@ The Wave 3 Mission Outline Plan codified our contributor workflow, including the
 - `black` formats Python code deterministically.
 - `mypy` performs static type checks using the repository configuration.
 
-The `.github/workflows/ci.yml` pipeline executes `scripts/ci/run_precommit.sh` ahead of tests. A failure here blocks packaging and deployment jobs downstream.
+The `.github/workflows/ci.yml` pipeline now runs the same tooling directly—`ruff check .`, `black --check .`, `mypy --config-file mypy.ini -p releasecopilot`, and `pytest --cov=src --cov-report=xml` followed by `scripts/ci/coverage_gate.py`. Any failure blocks packaging and deployment jobs downstream.
+
+### Test isolation policies
+
+- `tests/conftest.py` provides the global `config.settings` stub and enforces the Phoenix timezone plus `ENABLE_NETWORK = False`.
+- Socket creation is blocked session-wide; live HTTP calls should raise immediately.
+- Tests must not edit `sys.path` or mutate `sys.modules`; prefer `importlib.reload` and monkeypatching of imported symbols.
 
 ## Troubleshooting
 

--- a/exporters/excel_exporter.py
+++ b/exporters/excel_exporter.py
@@ -13,9 +13,7 @@ class ExcelExporter:
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-    def export(
-        self, data: Dict[str, Any], filename: str = "audit_results.xlsx"
-    ) -> Path:
+    def export(self, data: Dict[str, Any], filename: str = "audit_results.xlsx") -> Path:
         output_path = self.output_dir / filename
         with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
             self._write_summary_sheet(data.get("summary", {}), writer)
@@ -24,15 +22,11 @@ class ExcelExporter:
                 "Stories Without Commits",
                 writer,
             )
-            self._write_table_sheet(
-                data.get("orphan_commits", []), "Orphan Commits", writer
-            )
+            self._write_table_sheet(data.get("orphan_commits", []), "Orphan Commits", writer)
             self._write_mapping_sheet(data.get("commit_story_mapping", []), writer)
         return output_path
 
-    def _write_summary_sheet(
-        self, summary: Dict[str, Any], writer: pd.ExcelWriter
-    ) -> None:
+    def _write_summary_sheet(self, summary: Dict[str, Any], writer: pd.ExcelWriter) -> None:
         df = pd.DataFrame([summary]) if summary else pd.DataFrame()
         df.to_excel(writer, sheet_name="Audit Summary", index=False)
 
@@ -45,9 +39,7 @@ class ExcelExporter:
         df = pd.json_normalize(items) if items else pd.DataFrame()
         df.to_excel(writer, sheet_name=sheet_name[:31], index=False)
 
-    def _write_mapping_sheet(
-        self, mappings: List[Dict[str, Any]], writer: pd.ExcelWriter
-    ) -> None:
+    def _write_mapping_sheet(self, mappings: List[Dict[str, Any]], writer: pd.ExcelWriter) -> None:
         rows: List[Dict[str, Any]] = []
         for mapping in mappings:
             commits = mapping.get("commits", [])

--- a/exporters/json_exporter.py
+++ b/exporters/json_exporter.py
@@ -12,9 +12,7 @@ class JSONExporter:
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-    def export(
-        self, data: Dict[str, Any], filename: str = "audit_results.json"
-    ) -> Path:
+    def export(self, data: Dict[str, Any], filename: str = "audit_results.json") -> Path:
         output_path = self.output_dir / filename
         with output_path.open("w", encoding="utf-8") as fh:
             json.dump(data, fh, indent=2)

--- a/infra/cdk/app.py
+++ b/infra/cdk/app.py
@@ -60,13 +60,9 @@ def _load_context(app: cdk.App) -> Dict[str, Any]:
         "lambdaTimeoutSec": int(_context(app, "lambdaTimeoutSec", 180)),
         "lambdaMemoryMb": int(_context(app, "lambdaMemoryMb", 512)),
         "jiraWebhookSecretArn": str(_context(app, "jiraWebhookSecretArn", "")),
-        "jiraBaseUrl": str(
-            _context(app, "jiraBaseUrl", "https://your-domain.atlassian.net")
-        ),
+        "jiraBaseUrl": str(_context(app, "jiraBaseUrl", "https://your-domain.atlassian.net")),
         "reconciliationCron": str(_context(app, "reconciliationCron", "")),
-        "reconciliationFixVersions": str(
-            _context(app, "reconciliationFixVersions", "")
-        ),
+        "reconciliationFixVersions": str(_context(app, "reconciliationFixVersions", "")),
         "reconciliationJqlTemplate": str(
             _context(
                 app,
@@ -77,16 +73,12 @@ def _load_context(app: cdk.App) -> Dict[str, Any]:
         "reconciliationScheduleEnabled": _to_bool(
             _context(app, "reconciliationScheduleEnabled", True)
         ),
-        "metricsNamespace": str(
-            _context(app, "metricsNamespace", "ReleaseCopilot/JiraSync")
-        ),
+        "metricsNamespace": str(_context(app, "metricsNamespace", "ReleaseCopilot/JiraSync")),
         "budgetAmount": float(_context(app, "budgetAmount", 500)),
         "budgetCurrency": str(_context(app, "budgetCurrency", "USD")),
         "budgetEmailRecipients": _csv_list(_context(app, "budgetEmailRecipients", "")),
         "budgetSnsTopicName": str(_context(app, "budgetSnsTopicName", "")),
-        "budgetExistingSnsTopicArn": str(
-            _context(app, "budgetExistingSnsTopicArn", "")
-        ),
+        "budgetExistingSnsTopicArn": str(_context(app, "budgetExistingSnsTopicArn", "")),
     }
 
 
@@ -112,9 +104,7 @@ def _aws_identity(region_hint: Optional[str]) -> Tuple[Optional[str], Optional[s
     return identity.get("Account"), resolved_region
 
 
-def _resolve_environment(
-    app: cdk.App, context: Dict[str, Any]
-) -> Tuple[Optional[str], str]:
+def _resolve_environment(app: cdk.App, context: Dict[str, Any]) -> Tuple[Optional[str], str]:
     account = _optional_str(context.get("account"))
     region = _optional_str(context.get("region"))
 

--- a/infra/cdk/constructs/budget_alerts.py
+++ b/infra/cdk/constructs/budget_alerts.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Iterable, Sequence
 
-from aws_cdk import aws_budgets as budgets, aws_iam as iam, aws_sns as sns
+from aws_cdk import aws_budgets as budgets
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_sns as sns
 from constructs import Construct
 
 
@@ -44,8 +46,7 @@ class BudgetAlerts(Construct):
                 self,
                 topic_id,
                 display_name=f"ReleaseCopilot {environment_name} Budget Alerts",
-                topic_name=sns_topic_name
-                or f"releasecopilot-{normalized_env}-budget-alerts",
+                topic_name=sns_topic_name or f"releasecopilot-{normalized_env}-budget-alerts",
             )
             topic.add_to_resource_policy(
                 iam.PolicyStatement(

--- a/infra/cdk/constructs/secret_access.py
+++ b/infra/cdk/constructs/secret_access.py
@@ -7,11 +7,14 @@ from typing import Iterable, Sequence
 
 from aws_cdk import (
     aws_iam as iam,
+)
+from aws_cdk import (
     aws_lambda as _lambda,
+)
+from aws_cdk import (
     aws_secretsmanager as secretsmanager,
 )
 from constructs import Construct
-
 
 _SENSITIVE_ENV_PREFIX = "SECRET_"
 

--- a/infra/cdk/core_stack.py
+++ b/infra/cdk/core_stack.py
@@ -10,20 +10,48 @@ from aws_cdk import (
     Duration,
     RemovalPolicy,
     Stack,
+)
+from aws_cdk import (
     aws_apigateway as apigateway,
+)
+from aws_cdk import (
     aws_cloudwatch as cw,
+)
+from aws_cdk import (
     aws_cloudwatch_actions as actions,
+)
+from aws_cdk import (
     aws_dynamodb as dynamodb,
+)
+from aws_cdk import (
     aws_events as events,
+)
+from aws_cdk import (
     aws_events_targets as targets,
+)
+from aws_cdk import (
     aws_iam as iam,
+)
+from aws_cdk import (
     aws_lambda as _lambda,
+)
+from aws_cdk import (
     aws_logs as logs,
+)
+from aws_cdk import (
     aws_s3 as s3,
+)
+from aws_cdk import (
     aws_secretsmanager as secretsmanager,
-    aws_sqs as sqs,
+)
+from aws_cdk import (
     aws_sns as sns,
+)
+from aws_cdk import (
     aws_sns_subscriptions as subs,
+)
+from aws_cdk import (
+    aws_sqs as sqs,
 )
 from constructs import Construct
 
@@ -86,9 +114,7 @@ class CoreStack(Stack):
         asset_path = Path(lambda_asset_path).expanduser().resolve()
         project_root = Path(__file__).resolve().parents[2]
         webhook_asset_path = project_root / "services" / "jira_sync_webhook"
-        reconciliation_asset_path = (
-            project_root / "services" / "jira_reconciliation_job"
-        )
+        reconciliation_asset_path = project_root / "services" / "jira_reconciliation_job"
 
         if not webhook_asset_path.exists():
             raise FileNotFoundError(
@@ -278,12 +304,8 @@ class CoreStack(Stack):
         self.jira_table = dynamodb.Table(
             self,
             "JiraIssuesTable",
-            partition_key=dynamodb.Attribute(
-                name="issue_key", type=dynamodb.AttributeType.STRING
-            ),
-            sort_key=dynamodb.Attribute(
-                name="updated_at", type=dynamodb.AttributeType.STRING
-            ),
+            partition_key=dynamodb.Attribute(name="issue_key", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="updated_at", type=dynamodb.AttributeType.STRING),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.RETAIN,
             encryption=dynamodb.TableEncryption.AWS_MANAGED,
@@ -302,35 +324,23 @@ class CoreStack(Stack):
             partition_key=dynamodb.Attribute(
                 name="fix_version", type=dynamodb.AttributeType.STRING
             ),
-            sort_key=dynamodb.Attribute(
-                name="updated_at", type=dynamodb.AttributeType.STRING
-            ),
+            sort_key=dynamodb.Attribute(name="updated_at", type=dynamodb.AttributeType.STRING),
             projection_type=dynamodb.ProjectionType.ALL,
         )
         self.jira_table.add_global_secondary_index(
             index_name="StatusIndex",
-            partition_key=dynamodb.Attribute(
-                name="status", type=dynamodb.AttributeType.STRING
-            ),
-            sort_key=dynamodb.Attribute(
-                name="updated_at", type=dynamodb.AttributeType.STRING
-            ),
+            partition_key=dynamodb.Attribute(name="status", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="updated_at", type=dynamodb.AttributeType.STRING),
             projection_type=dynamodb.ProjectionType.ALL,
         )
         self.jira_table.add_global_secondary_index(
             index_name="AssigneeIndex",
-            partition_key=dynamodb.Attribute(
-                name="assignee", type=dynamodb.AttributeType.STRING
-            ),
-            sort_key=dynamodb.Attribute(
-                name="updated_at", type=dynamodb.AttributeType.STRING
-            ),
+            partition_key=dynamodb.Attribute(name="assignee", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="updated_at", type=dynamodb.AttributeType.STRING),
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
-        self.lambda_function.add_environment(
-            "JIRA_TABLE_NAME", self.jira_table.table_name
-        )
+        self.lambda_function.add_environment("JIRA_TABLE_NAME", self.jira_table.table_name)
         self.jira_table.grant_read_data(self.lambda_function)
 
         webhook_secret = self._resolve_secret(
@@ -484,9 +494,7 @@ class CoreStack(Stack):
         self._alarm_action = self._configure_alarm_action()
         self._add_lambda_alarms()
         self._add_reconciliation_dlq_alarm()
-        self._add_schedule(
-            schedule_enabled=schedule_enabled, schedule_cron=schedule_cron
-        )
+        self._add_schedule(schedule_enabled=schedule_enabled, schedule_cron=schedule_cron)
 
         self._add_reconciliation_schedule(
             enable_schedule=enable_reconciliation_schedule,
@@ -516,12 +524,8 @@ class CoreStack(Stack):
             "JiraReconciliationLambdaName",
             value=self.reconciliation_lambda.function_name,
         )
-        CfnOutput(
-            self, "JiraReconciliationDlqArn", value=self.reconciliation_dlq.queue_arn
-        )
-        CfnOutput(
-            self, "JiraReconciliationDlqUrl", value=self.reconciliation_dlq.queue_url
-        )
+        CfnOutput(self, "JiraReconciliationDlqArn", value=self.reconciliation_dlq.queue_arn)
+        CfnOutput(self, "JiraReconciliationDlqUrl", value=self.reconciliation_dlq.queue_url)
 
     def _attach_policies(self) -> None:
         log_group_arns = [
@@ -529,9 +533,7 @@ class CoreStack(Stack):
             self.webhook_lambda_log_group.log_group_arn,
             self.reconciliation_lambda_log_group.log_group_arn,
         ]
-        secret_arns = sorted(
-            {grant.secret.secret_arn for grant in self.secret_access.grants}
-        )
+        secret_arns = sorted({grant.secret.secret_arn for grant in self.secret_access.grants})
 
         statements: list[iam.PolicyStatement] = []
         if secret_arns:
@@ -675,9 +677,7 @@ class CoreStack(Stack):
         secret_name: str,
     ) -> secretsmanager.ISecret:
         if provided_arn:
-            return secretsmanager.Secret.from_secret_complete_arn(
-                self, construct_id, provided_arn
-            )
+            return secretsmanager.Secret.from_secret_complete_arn(self, construct_id, provided_arn)
         return secretsmanager.Secret(
             self,
             construct_id,
@@ -730,11 +730,9 @@ class CoreStack(Stack):
             throttles_alarm.add_alarm_action(self._alarm_action)
 
     def _add_reconciliation_dlq_alarm(self) -> None:
-        dlq_metric = (
-            self.reconciliation_dlq.metric_approximate_number_of_messages_visible(
-                period=Duration.minutes(5),
-                statistic="sum",
-            )
+        dlq_metric = self.reconciliation_dlq.metric_approximate_number_of_messages_visible(
+            period=Duration.minutes(5),
+            statistic="sum",
         )
 
         dlq_alarm = cw.Alarm(
@@ -753,9 +751,7 @@ class CoreStack(Stack):
         if self._alarm_action:
             dlq_alarm.add_alarm_action(self._alarm_action)
 
-    def _add_schedule(
-        self, *, schedule_enabled: bool, schedule_cron: str | None
-    ) -> None:
+    def _add_schedule(self, *, schedule_enabled: bool, schedule_cron: str | None) -> None:
         """Provision the optional EventBridge rule when scheduling is enabled.
 
         Skipping creation when ``schedule_enabled`` is false ensures the stack

--- a/main.py
+++ b/main.py
@@ -37,7 +37,6 @@ from processors.audit_processor import AuditProcessor
 from releasecopilot import uploader
 from releasecopilot.errors import ReleaseCopilotError
 from releasecopilot.logging_config import configure_logging, get_logger
-
 from src.cli.shared import AuditConfig, finalize_run, handle_dry_run, parse_args
 from tools.generator.generator import run_cli as run_generator_cli
 
@@ -160,9 +159,7 @@ def run_audit(
         use_cache=config.use_cache,
     )
     commits_output = DATA_DIR / "bitbucket_commits.json"
-    write_json(
-        commits_output, {"repos": repos, "branches": branches, "commits": commits}
-    )
+    write_json(commits_output, {"repos": repos, "branches": branches, "commits": commits})
 
     processor = AuditProcessor(issues=issues, commits=commits)
     audit_result = processor.process()
@@ -342,13 +339,9 @@ def upload_artifacts(
     temp_dir = staging_root / "temp_data"
 
     json_reports = [path for path in reports if Path(path).suffix.lower() == ".json"]
-    excel_reports = [
-        path for path in reports if Path(path).suffix.lower() in {".xls", ".xlsx"}
-    ]
+    excel_reports = [path for path in reports if Path(path).suffix.lower() in {".xls", ".xlsx"}]
     other_reports = [
-        path
-        for path in reports
-        if Path(path).suffix.lower() not in {".json", ".xls", ".xlsx"}
+        path for path in reports if Path(path).suffix.lower() not in {".json", ".xls", ".xlsx"}
     ]
     if other_reports:
         logger.warning(
@@ -417,9 +410,7 @@ def _stage_files(target_dir: Path, sources: Iterable[Path]) -> None:
 
 def _detect_git_sha() -> Optional[str]:
     try:
-        output = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
-        )
+        output = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
     except (OSError, subprocess.CalledProcessError):
         return None
     sha = output.decode("utf-8").strip()

--- a/processors/audit_processor.py
+++ b/processors/audit_processor.py
@@ -24,9 +24,7 @@ class AuditResult:
 class AuditProcessor:
     """Links commits with their corresponding Jira issues."""
 
-    def __init__(
-        self, issues: Iterable[Dict[str, Any]], commits: Iterable[Dict[str, Any]]
-    ) -> None:
+    def __init__(self, issues: Iterable[Dict[str, Any]], commits: Iterable[Dict[str, Any]]) -> None:
         self.issues = list(issues)
         self.commits = list(commits)
 
@@ -55,9 +53,7 @@ class AuditProcessor:
             commit_story_mapping.append(
                 {
                     "story_key": key,
-                    "story_summary": (
-                        issue.get("fields", {}).get("summary") if issue else None
-                    ),
+                    "story_summary": (issue.get("fields", {}).get("summary") if issue else None),
                     "commit_count": len(commits),
                     "commits": [self._simplify_commit(commit) for commit in commits],
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["releasecopilot", "src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,9 @@
 [pytest]
-pythonpath = src .
+pythonpath =
+    src
+    .
 testpaths = tests
-addopts = --import-mode=importlib
+addopts = -q --maxfail=1 --durations=10 --disable-warnings --import-mode=importlib
 markers =
     integration: integration-level recovery tool tests
 

--- a/rag-aws/services/ingest/jira_ingestor/handler.py
+++ b/rag-aws/services/ingest/jira_ingestor/handler.py
@@ -206,13 +206,9 @@ def normalize_issue(
     return normalized
 
 
-def _write_json_to_s3(
-    s3_client, bucket: str, key: str, payload: Dict[str, Any]
-) -> None:
+def _write_json_to_s3(s3_client, bucket: str, key: str, payload: Dict[str, Any]) -> None:
     body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
-    s3_client.put_object(
-        Bucket=bucket, Key=key, Body=body, ContentType="application/json"
-    )
+    s3_client.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
 
 
 def _load_secret(secret_id: str) -> Dict[str, Any]:
@@ -278,13 +274,9 @@ def _run_ingestion() -> Dict[str, Any]:
 
     field_map = discover_field_map(base_url, access_token)
     if not field_map.get("acceptance_criteria"):
-        LOGGER.warning(
-            "Acceptance Criteria field not discovered; output will omit this field"
-        )
+        LOGGER.warning("Acceptance Criteria field not discovered; output will omit this field")
     if not field_map.get("deployment_notes"):
-        LOGGER.warning(
-            "Deployment Notes field not discovered; output will omit this field"
-        )
+        LOGGER.warning("Deployment Notes field not discovered; output will omit this field")
 
     fields = list(BASE_FIELDS)
     if field_map.get("acceptance_criteria"):
@@ -311,22 +303,16 @@ def _run_ingestion() -> Dict[str, Any]:
         )
         issues = _as_dict_list(page.get("issues"))
         total = _to_int(page.get("total"), 0)
-        LOGGER.info(
-            "Fetched page startAt=%s count=%s total=%s", start_at, len(issues), total
-        )
+        LOGGER.info("Fetched page startAt=%s count=%s total=%s", start_at, len(issues), total)
 
         if not issues:
             break
 
         for issue in issues:
             fields_raw = issue.get("fields")
-            fields_data: Dict[str, Any] = (
-                fields_raw if isinstance(fields_raw, dict) else {}
-            )
+            fields_data: Dict[str, Any] = fields_raw if isinstance(fields_raw, dict) else {}
             comment_field = fields_data.get("comment")
-            comment_info: Dict[str, Any] = (
-                comment_field if isinstance(comment_field, dict) else {}
-            )
+            comment_info: Dict[str, Any] = comment_field if isinstance(comment_field, dict) else {}
             initial_comments = _as_dict_list(comment_info.get("comments"))
             total_comments = _to_int(comment_info.get("total"), len(initial_comments))
             issue_id = issue.get("id")
@@ -366,9 +352,7 @@ def _run_ingestion() -> Dict[str, Any]:
             _write_json_to_s3(s3_client, s3_bucket, normalized_key, normalized)
 
             updated_value = _parse_updated(fields_data.get("updated"))
-            if updated_value and (
-                latest_updated is None or updated_value > latest_updated
-            ):
+            if updated_value and (latest_updated is None or updated_value > latest_updated):
                 latest_updated = updated_value
 
             issues_processed += 1

--- a/rag-aws/services/ingest/jira_ingestor/jira_api.py
+++ b/rag-aws/services/ingest/jira_ingestor/jira_api.py
@@ -91,9 +91,7 @@ def _request(
         raise JiraTransientError(f"Jira 5xx error: {response.status_code}")
 
     if response.status_code >= 400:
-        raise JiraAuthError(
-            f"Jira returned HTTP {response.status_code}: {response.text}"
-        )
+        raise JiraAuthError(f"Jira returned HTTP {response.status_code}: {response.text}")
 
     return response
 
@@ -124,9 +122,7 @@ def refresh_access_token(client_id: str, client_secret: str, refresh_token: str)
     return token
 
 
-def jira_get(
-    base_url: str, token: str, path: str, params: Optional[Mapping[str, Any]] = None
-):
+def jira_get(base_url: str, token: str, path: str, params: Optional[Mapping[str, Any]] = None):
     """Perform a GET request against the Jira REST API with retry semantics."""
 
     url = _build_url(base_url, path)
@@ -161,8 +157,7 @@ def discover_field_map(
     }
 
     normalized_targets = {
-        key: {_normalize_synonym(value) for value in values}
-        for key, values in synonym_map.items()
+        key: {_normalize_synonym(value) for value in values} for key, values in synonym_map.items()
     }
 
     discovered: Dict[str, Optional[str]] = {key: None for key in normalized_targets}

--- a/recover_and_export.py
+++ b/recover_and_export.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Iterable
 
 from src.export.exporter import build_export_payload, export_all
 
-
 LOGGER = logging.getLogger("recover")
 
 REQUIRED_FILES = {
@@ -27,9 +26,7 @@ class MissingInputError(RuntimeError):
 
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Rebuild export artifacts from cached payloads"
-    )
+    parser = argparse.ArgumentParser(description="Rebuild export artifacts from cached payloads")
     parser.add_argument(
         "--input-dir",
         default="temp_data/",
@@ -70,9 +67,7 @@ def load_inputs(input_dir: Path) -> Dict[str, Dict[str, Any]]:
         else:
             metadata = {"length": len(payload) if hasattr(payload, "__len__") else None}
         LOGGER.info(
-            json.dumps(
-                {"event": "input_loaded", "name": key, "path": str(path), **metadata}
-            )
+            json.dumps({"event": "input_loaded", "name": key, "path": str(path), **metadata})
         )
     return inputs
 
@@ -107,9 +102,7 @@ def build_payload_from_inputs(inputs: Dict[str, Dict[str, Any]]) -> Dict[str, An
         data={
             "summary": _ensure_dict(inputs["summary"]),
             "stories_with_no_commits": _ensure_list(
-                _extract(
-                    inputs["stories"], "stories_with_no_commits", "stories", "items"
-                )
+                _extract(inputs["stories"], "stories_with_no_commits", "stories", "items")
             ),
             "orphan_commits": _ensure_list(
                 _extract(inputs["commits"], "orphan_commits", "commits", "items")
@@ -135,9 +128,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     try:
         inputs = load_inputs(input_dir)
         payload = build_payload_from_inputs(inputs)
-        outputs = export_all(
-            payload, out_dir=output_dir, formats=parse_formats(args.format)
-        )
+        outputs = export_all(payload, out_dir=output_dir, formats=parse_formats(args.format))
     except MissingInputError as exc:
         LOGGER.error(json.dumps({"event": "missing_input", "message": str(exc)}))
         print(str(exc), file=sys.stderr)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,6 @@ jsonschema>=4.23.0
 black==24.10.0
 mypy==1.11.2
 pre-commit==3.8.0
+types-PyYAML==6.0.12.20240808
 
 ruamel.yaml==0.18.6

--- a/scripts/ci/coverage_gate.py
+++ b/scripts/ci/coverage_gate.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Enforce the repository coverage threshold and surface uncovered lines."""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import List, Tuple
+
+THRESHOLD = float(os.environ.get("COVERAGE_THRESHOLD", "70"))
+
+
+def _load_report(path: Path) -> ET.Element:
+    try:
+        return ET.parse(path).getroot()
+    except ET.ParseError as exc:  # pragma: no cover - defensive
+        raise SystemExit(f"Failed to parse coverage report {path}: {exc}") from exc
+
+
+def _collect_uncovered(root: ET.Element) -> List[Tuple[str, float, List[int]]]:
+    uncovered: List[Tuple[str, float, List[int]]] = []
+    for cls in root.findall(".//class"):
+        filename = cls.attrib.get("filename")
+        if not filename:
+            continue
+        line_rate = float(cls.attrib.get("line-rate", "0")) * 100
+        missing: List[int] = []
+        for line in cls.findall("lines/line"):
+            hits = int(line.attrib.get("hits", "0"))
+            if hits == 0:
+                missing.append(int(line.attrib.get("number", "0")))
+        if missing:
+            uncovered.append((filename, line_rate, sorted(missing)))
+    uncovered.sort(key=lambda item: (item[1], -len(item[2])))
+    return uncovered
+
+
+def main(argv: List[str]) -> int:
+    report_path = Path(argv[1]) if len(argv) > 1 else Path("coverage.xml")
+    if not report_path.exists():
+        print(f"Coverage report not found: {report_path}", file=sys.stderr)
+        return 1
+
+    root = _load_report(report_path)
+    total_rate = float(root.attrib.get("line-rate", "0")) * 100
+    print(f"Overall coverage: {total_rate:.2f}% (required: {THRESHOLD:.2f}%)")
+
+    uncovered = _collect_uncovered(root)[:5]
+    if uncovered:
+        print("Most uncovered files:")
+        for filename, rate, missing in uncovered:
+            preview = ", ".join(str(num) for num in missing[:5])
+            print(f"  - {filename} — {rate:.2f}% covered; first uncovered lines: {preview}")
+    else:
+        print("All tracked lines executed at least once in tests.")
+
+    if total_rate < THRESHOLD:
+        print(
+            f"Coverage check failed: {total_rate:.2f}% < {THRESHOLD:.2f}% threshold",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/compose_policies.py
+++ b/scripts/compose_policies.py
@@ -26,9 +26,7 @@ def _dynamodb_arns(region: str, account: str, tables: Iterable[str]) -> list[str
 
 
 def _secret_arns(region: str, account: str, secrets: Iterable[str]) -> list[str]:
-    return [
-        f"arn:aws:secretsmanager:{region}:{account}:secret:{name}" for name in secrets
-    ]
+    return [f"arn:aws:secretsmanager:{region}:{account}:secret:{name}" for name in secrets]
 
 
 def _role_arns(account: str, roles: Iterable[str]) -> list[str]:

--- a/scripts/deploy_env.py
+++ b/scripts/deploy_env.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
-
 LOGGER = logging.getLogger("deploy_env")
 
 
@@ -28,9 +27,7 @@ def _as_bool(value: Any) -> bool:
 def _load_env_config(env_name: str) -> Dict[str, Any]:
     root = Path(__file__).resolve().parents[1]
     env_dir = root / "infra" / "envs"
-    candidates = [
-        env_dir / f"{env_name}{suffix}" for suffix in (".json", ".yaml", ".yml")
-    ]
+    candidates = [env_dir / f"{env_name}{suffix}" for suffix in (".json", ".yaml", ".yml")]
 
     for path in candidates:
         if not path.exists():
@@ -58,24 +55,18 @@ def _normalise_context(
     context: Dict[str, Any] = {}
     context["env"] = config.get("env", env_override)
     context["project"] = config.get("project", "releasecopilot")
-    context["region"] = config.get(
-        "region", os.getenv("CDK_DEFAULT_REGION", "us-west-2")
-    )
+    context["region"] = config.get("region", os.getenv("CDK_DEFAULT_REGION", "us-west-2"))
     context["bucketBase"] = config.get("bucketBase")
     context["reportPrefix"] = config.get("reportPrefix", "artifacts/json/")
     context["rawPrefix"] = config.get("rawPrefix", "temp_data/")
     context["logLevel"] = config.get("logLevel", "INFO")
     context["lambdaModule"] = config.get("lambdaModule", "aws.core_handler")
-    context["retainBucket"] = _as_bool(
-        config.get("retainBucket", context["env"] == "prod")
-    )
+    context["retainBucket"] = _as_bool(config.get("retainBucket", context["env"] == "prod"))
     context["scheduleCron"] = config.get("scheduleCron", "cron(30 8 * * ? *)")
 
     secrets = config.get("secrets", {})
     if not isinstance(secrets, dict):
-        raise ValueError(
-            "`secrets` must be an object mapping logical names to secret names"
-        )
+        raise ValueError("`secrets` must be an object mapping logical names to secret names")
     context["secrets"] = secrets
 
     schedule_enabled = _as_bool(config.get("scheduleEnabled", False))
@@ -111,9 +102,7 @@ def _package_lambda(root: Path) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Deploy the audit CDK stacks for an environment"
-    )
+    parser = argparse.ArgumentParser(description="Deploy the audit CDK stacks for an environment")
     parser.add_argument(
         "--env",
         required=True,

--- a/scripts/github/check_comment_permissions.py
+++ b/scripts/github/check_comment_permissions.py
@@ -117,9 +117,7 @@ def main() -> None:
 
     # If no roles or users are configured we fail closed.
     if not allowed_roles and not allowed_users:
-        raise PermissionError(
-            "No allowed roles or users configured for orchestrator dispatch."
-        )
+        raise PermissionError("No allowed roles or users configured for orchestrator dispatch.")
 
     if event_name == "issue_comment":
         _validate_issue_comment(payload, allowed_roles, allowed_users, command)

--- a/scripts/github/projects_v2.py
+++ b/scripts/github/projects_v2.py
@@ -79,9 +79,7 @@ class ProjectsV2Client:
                     continue
                 assignees = [
                     assignee.get("login")
-                    for assignee in (content.get("assignees", {}) or {}).get(
-                        "nodes", []
-                    )
+                    for assignee in (content.get("assignees", {}) or {}).get("nodes", [])
                     if assignee and assignee.get("login")
                 ]
                 items.append(
@@ -99,9 +97,7 @@ class ProjectsV2Client:
             after = page_info.get("endCursor")
         return items
 
-    def _resolve_project_id(
-        self, owner: str, repo: str, project_name: str
-    ) -> Optional[str]:
+    def _resolve_project_id(self, owner: str, repo: str, project_name: str) -> Optional[str]:
         """Look up the GraphQL node ID for a repository project."""
 
         data = self._execute(
@@ -111,34 +107,23 @@ class ProjectsV2Client:
                 "name": repo,
             },
         )
-        projects = (
-            data.get("data", {})
-            .get("repository", {})
-            .get("projectsV2", {})
-            .get("nodes", [])
-        )
+        projects = data.get("data", {}).get("repository", {}).get("projectsV2", {}).get("nodes", [])
         for project in projects:
             if (project or {}).get("title") == project_name:
                 return project.get("id")
         return None
 
-    def _execute(
-        self, query: str, variables: Dict[str, Optional[str]]
-    ) -> Dict[str, object]:
+    def _execute(self, query: str, variables: Dict[str, Optional[str]]) -> Dict[str, object]:
         response = self.session.post(
             _GRAPHQL_URL,
             json={"query": query, "variables": variables},
             timeout=30,
         )
         if response.status_code >= 400:
-            raise RuntimeError(
-                f"GitHub GraphQL error {response.status_code}: {response.text}"
-            )
+            raise RuntimeError(f"GitHub GraphQL error {response.status_code}: {response.text}")
         data = response.json()
         if errors := data.get("errors"):
-            message = ", ".join(
-                error.get("message", "unknown error") for error in errors
-            )
+            message = ", ".join(error.get("message", "unknown error") for error in errors)
             raise RuntimeError(f"GitHub GraphQL returned errors: {message}")
         return data
 

--- a/scripts/github/wave2_helper.py
+++ b/scripts/github/wave2_helper.py
@@ -14,17 +14,15 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
 import click
+import yaml
 from jinja2 import Environment, FileSystemLoader
 from slugify import slugify
-import yaml
 
 from tools.generator.generator import TimezoneLabel, format_timezone_label
 
 try:
     from releasecopilot.logging_config import get_logger
-except (
-    ModuleNotFoundError
-):  # pragma: no cover - runtime fallback for python -m execution
+except ModuleNotFoundError:  # pragma: no cover - runtime fallback for python -m execution
     sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
     from releasecopilot.logging_config import get_logger
 
@@ -64,12 +62,9 @@ class Wave2HelperConfig:
                 for key, value in (payload.get("label_weights") or {}).items()
             },
             maintainers=list(payload.get("maintainers", [])),
-            target_labels=[
-                (label or "").lower() for label in payload.get("target_labels", [])
-            ],
+            target_labels=[(label or "").lower() for label in payload.get("target_labels", [])],
             artifact_dirs={
-                key: str(value)
-                for key, value in (payload.get("artifact_dirs") or {}).items()
+                key: str(value) for key, value in (payload.get("artifact_dirs") or {}).items()
             },
             mop_constraints=dict(payload.get("mop_constraints", {})),
         )
@@ -333,9 +328,7 @@ class Wave2Helper:
             lines.append(f"- Aligns with #{primary.number} – {primary.title}.")
         else:
             lines.append("- Backlog automation support tasks.")
-        lines.append(
-            "- Ensures Phoenix-local scheduling context and deterministic artifacts."
-        )
+        lines.append("- Ensures Phoenix-local scheduling context and deterministic artifacts.")
         lines.append("")
         lines.append("## Testing")
         lines.append("- [ ] `pytest tests/github/test_wave2_helper.py` (offline)")
@@ -443,9 +436,7 @@ def load_spec(path: Path | str) -> dict[str, Any]:
         result: list[str] = []
         for entry in values:
             if isinstance(entry, dict):
-                result.append(
-                    ", ".join(f"{key}: {value}" for key, value in entry.items())
-                )
+                result.append(", ".join(f"{key}: {value}" for key, value in entry.items()))
             else:
                 result.append(str(entry))
         return result
@@ -589,9 +580,7 @@ def render_subprompts_and_issues(
     return items
 
 
-def write_manifest(
-    wave: int, items: list[dict[str, Any]], generated_at: str | None = None
-) -> Path:
+def write_manifest(wave: int, items: list[dict[str, Any]], generated_at: str | None = None) -> Path:
     """Write the manifest describing generated sub-prompts."""
 
     manifest_path = Path("artifacts/manifests") / f"wave{wave}_subprompts.json"

--- a/scripts/promptops/human_actions.py
+++ b/scripts/promptops/human_actions.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
 from typing import Iterable, List, Sequence
-
 from zoneinfo import ZoneInfo
 
 PHOENIX_ZONE = ZoneInfo("America/Phoenix")
@@ -126,10 +125,7 @@ def parse_global_constraints(mop_text: str) -> List[str]:
             capture = True
             continue
         if capture:
-            if (
-                line.startswith("##")
-                and line.strip().lower() != "## global constraints"
-            ):
+            if line.startswith("##") and line.strip().lower() != "## global constraints":
                 break
             stripped = line.strip()
             if stripped.startswith("-"):
@@ -152,9 +148,7 @@ def extract_issue_number(text: str) -> int | None:
 
 def format_phoenix_timestamp(dt: datetime) -> str:
     if dt.tzinfo is None:
-        raise ValueError(
-            "Naive datetime values are not supported; provide an explicit timezone."
-        )
+        raise ValueError("Naive datetime values are not supported; provide an explicit timezone.")
     phoenix_dt = dt.astimezone(PHOENIX_ZONE)
     offset = phoenix_dt.utcoffset() or timedelta(0)
     offset_hours = int(offset.total_seconds() // 3600)
@@ -211,11 +205,7 @@ def build_checklist(
     ordered_section_names = sorted(
         set(ordered_section_names),
         key=lambda name: (
-            (
-                0
-                if name == "Orchestrator Workflow"
-                else 1 if name == "Helpers Workflow" else 2
-            ),
+            (0 if name == "Orchestrator Workflow" else 1 if name == "Helpers Workflow" else 2),
             name,
         ),
     )
@@ -254,12 +244,8 @@ def build_checklist(
     lines.append(
         "- Confirm artifact timestamps reflect America/Phoenix with no DST shifts (UTC-7 year-round)."
     )
-    lines.append(
-        "- Escalate blockers to the orchestrator DRI using the runbook contacts."
-    )
-    lines.append(
-        "- Ensure no secrets or credentials were embedded in generated artifacts."
-    )
+    lines.append("- Escalate blockers to the orchestrator DRI using the runbook contacts.")
+    lines.append("- Ensure no secrets or credentials were embedded in generated artifacts.")
     lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
@@ -270,9 +256,9 @@ def build_calendar(metadata: GenerationMetadata, issues: Sequence[Issue]) -> dic
     dtstamp = metadata.timestamp.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
     events: List[str] = []
     for idx, issue in enumerate(issues):
-        start_date = datetime.combine(
-            base_date, time(hour=9), tzinfo=PHOENIX_ZONE
-        ) + timedelta(days=idx)
+        start_date = datetime.combine(base_date, time(hour=9), tzinfo=PHOENIX_ZONE) + timedelta(
+            days=idx
+        )
         end_date = start_date + timedelta(minutes=45)
         uid = f"{metadata.run_hash}-{issue.number}@releasecopilot"
         events.extend(
@@ -338,9 +324,7 @@ def write_text(path: Path, content: str) -> None:
 
 def write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def log_activity(
@@ -373,9 +357,7 @@ def log_activity(
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Generate Wave 2 human action artifacts."
-    )
+    parser = argparse.ArgumentParser(description="Generate Wave 2 human action artifacts.")
     parser.add_argument(
         "--mop-path",
         type=Path,

--- a/services/ingest/jira_ingestor/adf_md.py
+++ b/services/ingest/jira_ingestor/adf_md.py
@@ -14,9 +14,7 @@ def to_markdown(adf):
         elif t == "heading":
             level = node.get("attrs", {}).get("level", 1)
             hashes = "#" * max(1, min(6, level))
-            out.append(
-                hashes + " " + "".join(text_runs(node.get("content", []))) + "\n"
-            )
+            out.append(hashes + " " + "".join(text_runs(node.get("content", []))) + "\n")
         elif t == "bulletList":
             for li in node.get("content", []) or []:
                 # listItem -> paragraph(s)
@@ -26,9 +24,7 @@ def to_markdown(adf):
             i = 1
             for li in node.get("content", []) or []:
                 for p in li.get("content", []) or []:
-                    out.append(
-                        f"{i}. " + "".join(text_runs(p.get("content", []))) + "\n"
-                    )
+                    out.append(f"{i}. " + "".join(text_runs(p.get("content", []))) + "\n")
                 i += 1
         elif t == "codeBlock":
             lang = node.get("attrs", {}).get("language") or ""

--- a/services/ingest/jira_ingestor/handler.py
+++ b/services/ingest/jira_ingestor/handler.py
@@ -2,17 +2,17 @@ import datetime as dt
 import json
 import os
 import time
+
 import boto3
+from adf_md import to_markdown
 from jira_api import (
-    refresh_access_token,
-    search_page,
     discover_field_map,
     get_all_comments_if_needed,
+    refresh_access_token,
+    search_page,
 )
-from adf_md import to_markdown
 
 from releasecopilot.logging_config import configure_logging, get_logger
-
 
 configure_logging()
 LOGGER = get_logger(__name__)
@@ -75,13 +75,9 @@ def _normalize_issue(issue, field_ids, base_url):
     for link in f.get("issuelinks", []) or []:
         t = (link.get("type") or {}).get("name")
         if "outwardIssue" in link:
-            links.append(
-                {"type": t, "direction": "outward", "key": link["outwardIssue"]["key"]}
-            )
+            links.append({"type": t, "direction": "outward", "key": link["outwardIssue"]["key"]})
         if "inwardIssue" in link:
-            links.append(
-                {"type": t, "direction": "inward", "key": link["inwardIssue"]["key"]}
-            )
+            links.append({"type": t, "direction": "inward", "key": link["inwardIssue"]["key"]})
 
     # Custom fields
     ac_id = field_ids.get("acceptance_criteria")
@@ -98,12 +94,8 @@ def _normalize_issue(issue, field_ids, base_url):
         "status": (f.get("status") or {}).get("name"),
         "summary": f.get("summary"),
         "description": wrap(f.get("description")),
-        "acceptance_criteria": (
-            wrap(f.get(ac_id)) if ac_id else {"adf": None, "markdown": ""}
-        ),
-        "deployment_notes": (
-            wrap(f.get(dn_id)) if dn_id else {"adf": None, "markdown": ""}
-        ),
+        "acceptance_criteria": (wrap(f.get(ac_id)) if ac_id else {"adf": None, "markdown": ""}),
+        "deployment_notes": (wrap(f.get(dn_id)) if dn_id else {"adf": None, "markdown": ""}),
         "comments": norm_comments,
         "links": links,
         "labels": f.get("labels") or [],
@@ -158,9 +150,7 @@ def handler(event, context):
     total_processed = 0
 
     while True:
-        page = search_page(
-            base_url, token, jql, fields_csv, start_at=start, max_results=100
-        )
+        page = search_page(base_url, token, jql, fields_csv, start_at=start, max_results=100)
         issues = page.get("issues", [])
         if not issues:
             break

--- a/services/ingest/jira_ingestor/jira_api.py
+++ b/services/ingest/jira_ingestor/jira_api.py
@@ -1,7 +1,7 @@
 import time
 
 import requests
-from tenacity import retry, wait_exponential, stop_after_attempt
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 
 # --- OAuth token refresh ---

--- a/services/jira_sync_webhook/handler.py
+++ b/services/jira_sync_webhook/handler.py
@@ -12,8 +12,8 @@ from typing import Any, Dict, Optional
 import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
-from releasecopilot.logging_config import configure_logging, get_logger
 
+from releasecopilot.logging_config import configure_logging, get_logger
 
 configure_logging()
 LOGGER = get_logger(__name__)
@@ -68,9 +68,7 @@ def handler(
 
     event_type = payload.get("webhookEvent")
     if event_type not in ALLOWED_EVENTS:
-        LOGGER.info(
-            "Ignoring unsupported webhook event", extra={"event_type": event_type}
-        )
+        LOGGER.info("Ignoring unsupported webhook event", extra={"event_type": event_type})
         return _response(202, {"ignored": True})
 
     if event_type == "jira:issue_deleted":
@@ -150,18 +148,14 @@ def _handle_upsert(payload: Dict[str, Any]) -> Dict[str, Any]:
     issue = payload.get("issue") or {}
     issue_key = issue.get("key") or issue.get("id")
     if not issue_key:
-        LOGGER.error(
-            "Webhook payload missing issue identifier", extra={"payload": payload}
-        )
+        LOGGER.error("Webhook payload missing issue identifier", extra={"payload": payload})
         return {"success": False, "status": 400, "message": "Missing issue identifier"}
 
     issue_id = str(issue.get("id") or issue_key)
     issue_fields = issue.get("fields") or {}
     updated_at = (
         _normalize_timestamp(
-            issue_fields.get("updated")
-            or issue_fields.get("created")
-            or payload.get("timestamp")
+            issue_fields.get("updated") or issue_fields.get("created") or payload.get("timestamp")
         )
         or _now_iso()
     )
@@ -231,9 +225,7 @@ def _handle_delete(payload: Dict[str, Any]) -> Dict[str, Any]:
         )
         return {"success": False, "status": 500, "message": "Failed to delete issue"}
 
-    LOGGER.info(
-        "Deleted Jira issue", extra={"issue_key": issue_key, "tombstoned": tombstoned}
-    )
+    LOGGER.info("Deleted Jira issue", extra={"issue_key": issue_key, "tombstoned": tombstoned})
     return {"success": True, "issue_key": issue_key, "deleted": True}
 
 
@@ -314,9 +306,7 @@ def _fetch_latest_issue_item(issue_key: str) -> Optional[Dict[str, Any]]:
     return items[0]
 
 
-def _compute_idempotency_key(
-    payload: Dict[str, Any], issue_key: str, updated_at: str
-) -> str:
+def _compute_idempotency_key(payload: Dict[str, Any], issue_key: str, updated_at: str) -> str:
     for key in ("deliveryId", "delivery_id", "eventId", "event_id"):
         value = payload.get(key)
         if value:
@@ -364,9 +354,7 @@ def _normalize_timestamp(raw: Any) -> Optional[str]:
         return None
     if isinstance(raw, (int, float)):
         return (
-            datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc)
-            .isoformat()
-            .replace("+00:00", "Z")
+            datetime.fromtimestamp(raw / 1000.0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
         )
     text = str(raw)
     for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
@@ -379,12 +367,7 @@ def _normalize_timestamp(raw: Any) -> Optional[str]:
 
 
 def _now_iso() -> str:
-    return (
-        datetime.utcnow()
-        .replace(tzinfo=timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _response(status: int, body: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -32,9 +32,7 @@ def _scope_entry(value: str) -> tuple[str, str]:
     return key.strip(), parsed.strip()
 
 
-def _build_audit_parser(
-    subparsers: argparse._SubParsersAction, defaults: Defaults
-) -> None:
+def _build_audit_parser(subparsers: argparse._SubParsersAction, defaults: Defaults) -> None:
     audit = subparsers.add_parser(
         "audit",
         help="Generate release audit artifacts from cached payloads",
@@ -96,9 +94,7 @@ def build_parser(defaults: Defaults | None = None) -> argparse.ArgumentParser:
     return parser
 
 
-def _collect_audit_options(
-    args: argparse.Namespace, defaults: Defaults
-) -> AuditOptions:
+def _collect_audit_options(args: argparse.Namespace, defaults: Defaults) -> AuditOptions:
     scope: dict[str, str] = {}
     for key, value in args.scope:
         scope[key] = value

--- a/src/cli/audit.py
+++ b/src/cli/audit.py
@@ -118,9 +118,7 @@ def _build_export_payload(payloads: Mapping[str, Mapping[str, Any]]) -> Dict[str
                 "stories_with_no_commits", []
             ),
             "orphan_commits": payloads.get("commits", {}).get("orphan_commits", []),
-            "commit_story_mapping": payloads.get("links", {}).get(
-                "commit_story_mapping", []
-            ),
+            "commit_story_mapping": payloads.get("links", {}).get("commit_story_mapping", []),
         }
     )
 

--- a/src/cli/health.py
+++ b/src/cli/health.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+
 from releasecopilot.logging_config import get_logger
 
 from ..config.loader import (
@@ -25,9 +26,7 @@ class HealthCommandError(RuntimeError):
     """Raised when health command execution fails."""
 
 
-def register_health_parser(
-    subparsers: argparse._SubParsersAction, defaults: Defaults
-) -> None:
+def register_health_parser(subparsers: argparse._SubParsersAction, defaults: Defaults) -> None:
     parser = subparsers.add_parser(
         "health",
         help="Operational health checks",

--- a/src/cli/shared.py
+++ b/src/cli/shared.py
@@ -32,31 +32,19 @@ def build_parser() -> argparse.ArgumentParser:
     """Return the canonical argument parser for ReleaseCopilot CLI entry points."""
 
     parser = argparse.ArgumentParser(description="ReleaseCopilot audit runner")
-    parser.add_argument(
-        "--fix-version", required=True, help="Jira fix version to audit"
-    )
-    parser.add_argument(
-        "--repos", nargs="*", default=[], help="Bitbucket repositories to inspect"
-    )
+    parser.add_argument("--fix-version", required=True, help="Jira fix version to audit")
+    parser.add_argument("--repos", nargs="*", default=[], help="Bitbucket repositories to inspect")
     parser.add_argument("--branches", nargs="*", help="Optional branches to include")
-    parser.add_argument(
-        "--develop-only", action="store_true", help="Use the develop branch only"
-    )
+    parser.add_argument("--develop-only", action="store_true", help="Use the develop branch only")
     parser.add_argument("--freeze-date", help="ISO freeze date override")
-    parser.add_argument(
-        "--window-days", type=int, default=28, help="Lookback window in days"
-    )
-    parser.add_argument(
-        "--use-cache", action="store_true", help="Reuse cached payloads"
-    )
+    parser.add_argument("--window-days", type=int, default=28, help="Lookback window in days")
+    parser.add_argument("--use-cache", action="store_true", help="Reuse cached payloads")
     parser.add_argument("--s3-bucket", help="Override destination S3 bucket")
     parser.add_argument("--s3-prefix", help="Override destination S3 prefix")
     parser.add_argument(
         "--output-prefix", default="audit_results", help="Basename for generated files"
     )
-    parser.add_argument(
-        "--output", help="Optional directory to copy generated artifacts into"
-    )
+    parser.add_argument("--output", help="Optional directory to copy generated artifacts into")
     parser.add_argument(
         "--format",
         choices=["json", "excel", "both"],
@@ -94,9 +82,7 @@ def parse_args(
     return args, config
 
 
-def _select_artifacts(
-    artifacts: Mapping[str, str], format_preference: str
-) -> dict[str, str]:
+def _select_artifacts(artifacts: Mapping[str, str], format_preference: str) -> dict[str, str]:
     """Filter artifacts according to the requested ``--format`` value."""
 
     if format_preference == "both":

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -73,9 +73,7 @@ def _load_settings_file(path: Path) -> Dict[str, Any]:
     raise ValueError(f"Unsupported configuration format: {path}")
 
 
-def get_aws_region(
-    config: Mapping[str, Any], env: Mapping[str, str] | None = None
-) -> str | None:
+def get_aws_region(config: Mapping[str, Any], env: Mapping[str, str] | None = None) -> str | None:
     """Return the AWS region derived from configuration or environment."""
 
     env = env or os.environ
@@ -108,9 +106,7 @@ def get_dynamodb_table(config: Mapping[str, Any]) -> str | None:
 
     storage_cfg = config.get("storage", {}) if isinstance(config, Mapping) else {}
     if isinstance(storage_cfg, Mapping):
-        dynamodb_cfg = (
-            storage_cfg.get("dynamodb", {}) if isinstance(storage_cfg, Mapping) else {}
-        )
+        dynamodb_cfg = storage_cfg.get("dynamodb", {}) if isinstance(storage_cfg, Mapping) else {}
         if isinstance(dynamodb_cfg, Mapping):
             table_name = dynamodb_cfg.get("jira_issue_table")
             if table_name:
@@ -149,18 +145,10 @@ def load_defaults(env: Mapping[str, str] | None = None) -> Defaults:
     """
 
     env = env or os.environ
-    project_root = Path(
-        _env(env, "RC_ROOT", str(Path(__file__).resolve().parents[2]))
-    ).resolve()
-    cache_dir = Path(
-        _env(env, "RC_CACHE_DIR", str(project_root / "temp_data"))
-    ).resolve()
-    artifact_dir = Path(
-        _env(env, "RC_ARTIFACT_DIR", str(project_root / "dist"))
-    ).resolve()
-    reports_dir = Path(
-        _env(env, "RC_REPORTS_DIR", str(project_root / "reports"))
-    ).resolve()
+    project_root = Path(_env(env, "RC_ROOT", str(Path(__file__).resolve().parents[2]))).resolve()
+    cache_dir = Path(_env(env, "RC_CACHE_DIR", str(project_root / "temp_data"))).resolve()
+    artifact_dir = Path(_env(env, "RC_ARTIFACT_DIR", str(project_root / "dist"))).resolve()
+    reports_dir = Path(_env(env, "RC_REPORTS_DIR", str(project_root / "reports"))).resolve()
     settings_path = Path(
         _env(env, "RC_SETTINGS_FILE", str(project_root / "config" / "defaults.yml"))
     ).resolve()
@@ -245,9 +233,7 @@ def _deep_merge(base: Mapping[str, Any], override: Mapping[str, Any]) -> Dict[st
     return result
 
 
-def _set_path(
-    config: MutableMapping[str, Any], path: Sequence[str], value: Any
-) -> None:
+def _set_path(config: MutableMapping[str, Any], path: Sequence[str], value: Any) -> None:
     cursor: MutableMapping[str, Any] = config
     for segment in path[:-1]:
         existing = cursor.get(segment)
@@ -273,8 +259,8 @@ def _parse_env_value(key: str, value: str) -> Any:
     if key in _INT_ENV_KEYS:
         try:
             return int(value)
-        except (TypeError, ValueError):
-            raise ConfigurationError(f"Environment variable {key} must be an integer.")
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(f"Environment variable {key} must be an integer.") from exc
     lowered = value.lower().strip()
     if lowered in {"true", "1", "yes", "on"}:
         return True
@@ -283,9 +269,7 @@ def _parse_env_value(key: str, value: str) -> Any:
     return value
 
 
-def _apply_environment_overrides(
-    config: MutableMapping[str, Any], env: Mapping[str, str]
-) -> None:
+def _apply_environment_overrides(config: MutableMapping[str, Any], env: Mapping[str, str]) -> None:
     for env_key, path in _ENVIRONMENT_PATHS.items():
         if env_key not in env:
             continue
@@ -300,7 +284,7 @@ def _apply_secret_overrides(
     secrets_cfg = config.get("secrets")
     if not isinstance(secrets_cfg, Mapping):
         return
-    for secret_name, metadata in secrets_cfg.items():
+    for _secret_name, metadata in secrets_cfg.items():
         if not isinstance(metadata, Mapping):
             continue
         arn = metadata.get("arn")
@@ -363,9 +347,7 @@ def load_config(
     region = _get_path(config, ("aws", "region"))
     secrets_manager = credential_store
     if secrets_manager is None:
-        sm_client = SecretsManager(
-            region_name=region if isinstance(region, str) else None
-        )
+        sm_client = SecretsManager(region_name=region if isinstance(region, str) else None)
         secrets_manager = CredentialStore(secrets_manager=sm_client)
 
     _apply_secret_overrides(config, secrets_manager)

--- a/src/export/exporter.py
+++ b/src/export/exporter.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, Dict, Mapping as TypingMapping
+from typing import Any, Dict
+from typing import Mapping as TypingMapping
 
 from exporters.excel_exporter import ExcelExporter
 from exporters.json_exporter import JSONExporter
@@ -29,9 +30,7 @@ def build_export_payload(
     which are then merged into the expected structure.
     """
 
-    if data is not None and any(
-        item is not None for item in (matched, missing, orphans, summary)
-    ):
+    if data is not None and any(item is not None for item in (matched, missing, orphans, summary)):
         raise ValueError("Provide either `data` or the individual components, not both")
 
     if data is None:
@@ -46,13 +45,9 @@ def build_export_payload(
 
     return {
         "summary": dict(payload_source.get("summary", {})),
-        "stories_with_no_commits": list(
-            payload_source.get("stories_with_no_commits", []) or []
-        ),
+        "stories_with_no_commits": list(payload_source.get("stories_with_no_commits", []) or []),
         "orphan_commits": list(payload_source.get("orphan_commits", []) or []),
-        "commit_story_mapping": list(
-            payload_source.get("commit_story_mapping", []) or []
-        ),
+        "commit_story_mapping": list(payload_source.get("commit_story_mapping", []) or []),
     }
 
 
@@ -103,9 +98,7 @@ def export_all(
             path.parent.mkdir(parents=True, exist_ok=True)
             return path
         if base_dir is None:
-            raise ValueError(
-                "`out_dir` must be provided when explicit filenames are not supplied"
-            )
+            raise ValueError("`out_dir` must be provided when explicit filenames are not supplied")
         base_dir.mkdir(parents=True, exist_ok=True)
         return (base_dir / default).resolve()
 

--- a/src/ops/health.py
+++ b/src/ops/health.py
@@ -144,9 +144,7 @@ def _check_secrets(
     secret_status: MutableMapping[str, bool] = {}
     if not options.secrets:
         return (
-            CheckResult(
-                "pass", resource="secretsmanager://none", reason="No secrets requested"
-            ),
+            CheckResult("pass", resource="secretsmanager://none", reason="No secrets requested"),
             secret_status,
         )
 
@@ -161,9 +159,7 @@ def _check_secrets(
         for secret_id in options.secrets.values():
             secret_status[secret_id] = True
         return (
-            CheckResult(
-                "pass", resource=f"secretsmanager://{resource}", reason="Dry-run"
-            ),
+            CheckResult("pass", resource=f"secretsmanager://{resource}", reason="Dry-run"),
             secret_status,
         )
 
@@ -212,9 +208,7 @@ def _check_webhook(
         return CheckResult("pass", resource="webhook-secret", reason="Dry-run")
 
     if options.webhook_env_present:
-        LOGGER.info(
-            "Webhook secret resolved from environment", extra={"source": env_name}
-        )
+        LOGGER.info("Webhook secret resolved from environment", extra={"source": env_name})
         return CheckResult("pass", resource=f"env://{env_name}")
 
     secret_id = options.webhook_secret_id
@@ -303,9 +297,7 @@ def _check_dynamodb(
     if not key_schema:
         LOGGER.error("Table key schema missing", extra={"table_name": table_name})
         return (
-            CheckResult(
-                "fail", resource=f"dynamodb://{table_name}", reason="Missing key schema"
-            ),
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="Missing key schema"),
             None,
         )
 
@@ -316,9 +308,7 @@ def _check_dynamodb(
             extra={"table_name": table_name, "key_schema": key_schema},
         )
         return (
-            CheckResult(
-                "fail", resource=f"dynamodb://{table_name}", reason="Missing range key"
-            ),
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="Missing range key"),
             None,
         )
 
@@ -329,9 +319,7 @@ def _check_dynamodb(
             extra={"table_name": table_name, "key_schema": key_schema},
         )
         return (
-            CheckResult(
-                "fail", resource=f"dynamodb://{table_name}", reason="Missing range key"
-            ),
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="Missing range key"),
             None,
         )
 
@@ -352,9 +340,7 @@ def _check_dynamodb(
             extra={"table_name": table_name, "error": str(exc)},
         )
         return (
-            CheckResult(
-                "fail", resource=f"dynamodb://{table_name}", reason="PutItem failed"
-            ),
+            CheckResult("fail", resource=f"dynamodb://{table_name}", reason="PutItem failed"),
             None,
         )
 
@@ -362,9 +348,7 @@ def _check_dynamodb(
     try:
         client.delete_item(TableName=table_name, Key=item)
     except (BotoCoreError, ClientError) as exc:
-        cleanup_warning = (
-            f"Failed to delete DynamoDB sentinel ({exc.__class__.__name__})"
-        )
+        cleanup_warning = f"Failed to delete DynamoDB sentinel ({exc.__class__.__name__})"
         LOGGER.warning(
             "Failed to delete DynamoDB sentinel",
             extra={"table_name": table_name, "error": str(exc)},
@@ -398,9 +382,7 @@ def _check_s3(
 
     client = clients.s3
     sentinel = uuid.uuid4().hex
-    key_parts = [
-        part for part in (prefix, "health", "readiness", f"{sentinel}.txt") if part
-    ]
+    key_parts = [part for part in (prefix, "health", "readiness", f"{sentinel}.txt") if part]
     key = "/".join(key_parts)
     resource = f"s3://{bucket}/{key}"
 

--- a/src/releasecopilot/cli.py
+++ b/src/releasecopilot/cli.py
@@ -98,9 +98,7 @@ def _create_parser() -> argparse.ArgumentParser:
         "--config",
         help="Path to a releasecopilot.yaml file (defaults to ./releasecopilot.yaml if present)",
     )
-    parser.add_argument(
-        "--fix-version", dest="fix_version", help="Fix version to operate on"
-    )
+    parser.add_argument("--fix-version", dest="fix_version", help="Fix version to operate on")
     parser.add_argument(
         "--jira-base",
         dest="jira_base",
@@ -112,9 +110,7 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Base URL of the Bitbucket workspace",
     )
     parser.add_argument("--jira-user", dest="jira_user", help="Jira username or email")
-    parser.add_argument(
-        "--jira-token", dest="jira_token", help="Jira API token or password"
-    )
+    parser.add_argument("--jira-token", dest="jira_token", help="Jira API token or password")
     parser.add_argument(
         "--bitbucket-token",
         dest="bitbucket_token",

--- a/src/releasecopilot/cli/health.py
+++ b/src/releasecopilot/cli/health.py
@@ -13,9 +13,7 @@ _SECRET_ENV_VARS = ("SECRET_JIRA", "SECRET_BITBUCKET", "SECRET_WEBHOOK")
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="rc health", description="ReleaseCopilot health checks"
-    )
+    parser = argparse.ArgumentParser(prog="rc health", description="ReleaseCopilot health checks")
     subcommands = parser.add_subparsers(dest="command", required=True)
 
     readiness = subcommands.add_parser(
@@ -48,9 +46,7 @@ def _check_secret(env_key: str, secret_name: str, logger) -> bool:
     if secret is None:
         logger.error(
             "Unable to retrieve secret",
-            extra=safe_log_kv(
-                environment_variable=env_key, secret_identifier=secret_name
-            ),
+            extra=safe_log_kv(environment_variable=env_key, secret_identifier=secret_name),
         )
         print(f"FAIL {env_key} (unavailable)")
         return False
@@ -69,8 +65,7 @@ def _run_readiness(args: argparse.Namespace) -> int:
 
     names = _resolve_secret_names()
     results = [
-        _check_secret(env_key, secret_name, logger)
-        for env_key, secret_name in names.items()
+        _check_secret(env_key, secret_name, logger) for env_key, secret_name in names.items()
     ]
     return 0 if all(results) else 1
 

--- a/src/releasecopilot/config/__init__.py
+++ b/src/releasecopilot/config/__init__.py
@@ -208,8 +208,6 @@ def build_config(cli_args: argparse.Namespace) -> dict:
     required_fields = ("fix_version", "jira_base", "bitbucket_base")
     missing = [field for field in required_fields if not merged.get(field)]
     if missing:
-        raise ConfigError(
-            "Missing required configuration values: " + ", ".join(sorted(missing))
-        )
+        raise ConfigError("Missing required configuration values: " + ", ".join(sorted(missing)))
 
     return merged

--- a/src/releasecopilot/logging_config.py
+++ b/src/releasecopilot/logging_config.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any, Iterable
 
-
 _CONFIG_LOCK = threading.Lock()
 _CONFIGURED = False
 _CORRELATION_ID = os.getenv("RC_CORR_ID") or str(uuid.uuid4())
@@ -149,9 +148,7 @@ def configure_logging(level_override: str | None = None) -> None:
             use_json = os.getenv("RC_LOG_JSON", "false").lower() == "true"
             handler.addFilter(_CorrelationIdFilter())
             handler.addFilter(_RedactionFilter())
-            handler.setFormatter(
-                _JsonFormatter() if use_json else _StructuredFormatter()
-            )
+            handler.setFormatter(_JsonFormatter() if use_json else _StructuredFormatter())
             root.handlers = [handler]
             root.propagate = False
             _CONFIGURED = True

--- a/src/releasecopilot/orchestrator/command.py
+++ b/src/releasecopilot/orchestrator/command.py
@@ -90,18 +90,14 @@ class DispatchEnvelope:
             raise ValueError(f"Missing field in dispatch envelope: {exc}") from exc
 
         if not isinstance(command_payload, dict) or not isinstance(plan_payload, dict):
-            raise ValueError(
-                "Envelope payload must include mapping values for command and plan"
-            )
+            raise ValueError("Envelope payload must include mapping values for command and plan")
 
         command = SlashCommand(
             raw_text=str(command_payload.get("raw_text", "")),
             command_name=str(command_payload.get("command", "")),
             helper_prompt=str(command_payload.get("helper_prompt", "")),
             issue_number=int(command_payload.get("issue_number", 0)),
-            issued_at=_parse_phoenix_timestamp(
-                command_payload.get("phoenix_timestamp")
-            ),
+            issued_at=_parse_phoenix_timestamp(command_payload.get("phoenix_timestamp")),
         )
 
         plan = DispatchPlan(

--- a/src/releasecopilot/uploader.py
+++ b/src/releasecopilot/uploader.py
@@ -95,9 +95,7 @@ def upload_directory(
 
     for file_path in files:
         relative_key = file_path.relative_to(base_path)
-        key = "/".join(
-            filter(None, [combined_prefix, str(relative_key).replace("\\", "/")])
-        )
+        key = "/".join(filter(None, [combined_prefix, str(relative_key).replace("\\", "/")]))
         extra_args: dict[str, Any] = {"ServerSideEncryption": "AES256"}
         if normalized_metadata:
             extra_args["Metadata"] = normalized_metadata
@@ -108,9 +106,7 @@ def upload_directory(
         try:
             client.upload_file(str(file_path), bucket, key, ExtraArgs=extra_args)
         except (BotoCoreError, ClientError):  # pragma: no cover - network failure path
-            logger.exception(
-                "Failed to upload %s to s3://%s/%s", file_path, bucket, key
-            )
+            logger.exception("Failed to upload %s to s3://%s/%s", file_path, bucket, key)
             raise
         logger.info("Uploaded %s to s3://%s/%s", file_path, bucket, key)
 

--- a/src/releasecopilot/utils/logging.py
+++ b/src/releasecopilot/utils/logging.py
@@ -38,11 +38,7 @@ def redact(key: str | None, value: Any, *, placeholder: str = "***") -> Any:
 
     if isinstance(value, (list, tuple, set)):
         redacted_items = [
-            (
-                redact(key, item, placeholder=placeholder)
-                if isinstance(item, Mapping)
-                else item
-            )
+            (redact(key, item, placeholder=placeholder) if isinstance(item, Mapping) else item)
             for item in value
         ]
         if isinstance(value, tuple):

--- a/src/tracking/diff.py
+++ b/src/tracking/diff.py
@@ -6,9 +6,7 @@ from typing import Dict, List, Mapping, Sequence
 
 
 def _is_sequence(value: object) -> bool:
-    return isinstance(value, Sequence) and not isinstance(
-        value, (str, bytes, bytearray)
-    )
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
 
 
 def _story_index(run: Mapping[str, object]) -> Dict[str, Mapping[str, object]]:
@@ -103,9 +101,7 @@ def _diff_commit_lists(
     return added, removed
 
 
-def diff_runs(
-    old: Mapping[str, object], new: Mapping[str, object]
-) -> Dict[str, object]:
+def diff_runs(old: Mapping[str, object], new: Mapping[str, object]) -> Dict[str, object]:
     """Generate a deterministic diff structure between two audit runs."""
 
     old_index = _story_index(old)
@@ -129,16 +125,10 @@ def diff_runs(
         if old_status != new_status:
             status_changes.append({"key": key, "from": old_status, "to": new_status})
 
-        old_assignee = (
-            old_story.get("assignee") if isinstance(old_story, Mapping) else None
-        )
-        new_assignee = (
-            new_story.get("assignee") if isinstance(new_story, Mapping) else None
-        )
+        old_assignee = old_story.get("assignee") if isinstance(old_story, Mapping) else None
+        new_assignee = new_story.get("assignee") if isinstance(new_story, Mapping) else None
         if old_assignee != new_assignee:
-            assignee_changes.append(
-                {"key": key, "from": old_assignee, "to": new_assignee}
-            )
+            assignee_changes.append({"key": key, "from": old_assignee, "to": new_assignee})
 
     commits_added, commits_removed = _diff_commit_lists(old, new)
 

--- a/src/tracking/diff_cli.py
+++ b/src/tracking/diff_cli.py
@@ -20,12 +20,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--old", required=True, type=Path, help="Path to the previous JSON artifact"
     )
-    parser.add_argument(
-        "--new", required=True, type=Path, help="Path to the new JSON artifact"
-    )
-    parser.add_argument(
-        "--out", type=Path, help="Optional path to write the markdown summary"
-    )
+    parser.add_argument("--new", required=True, type=Path, help="Path to the new JSON artifact")
+    parser.add_argument("--out", type=Path, help="Optional path to write the markdown summary")
     parser.add_argument(
         "--json",
         dest="json_out",

--- a/tests/cli/test_orchestrator_cli.py
+++ b/tests/cli/test_orchestrator_cli.py
@@ -5,8 +5,8 @@ import json
 from pathlib import Path
 
 import pytest
-
 from cli.orchestrator import register_orchestrator_parser, run_orchestrator_command
+
 from config.loader import Defaults
 
 
@@ -34,15 +34,11 @@ def _build_parser(defaults: Defaults) -> argparse.ArgumentParser:
 def test_plan_creates_artifact(
     tmp_path: Path, defaults: Defaults, capsys: pytest.CaptureFixture[str]
 ):
-    prompt_path = (
-        defaults.project_root / "project" / "prompts" / "wave2" / "helper_prompt.md"
-    )
+    prompt_path = defaults.project_root / "project" / "prompts" / "wave2" / "helper_prompt.md"
     prompt_path.write_text("helper instructions", encoding="utf-8")
     event_path = tmp_path / "event.json"
     event_path.write_text(
-        Path("tests/fixtures/github_issue_comment_wave2.json").read_text(
-            encoding="utf-8"
-        ),
+        Path("tests/fixtures/github_issue_comment_wave2.json").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
 
@@ -60,9 +56,7 @@ def test_plan_creates_artifact(
     assert payload["command"]["helper_prompt"] == "helper_prompt"
 
 
-def test_plan_requires_helper_token(
-    defaults: Defaults, capsys: pytest.CaptureFixture[str]
-):
+def test_plan_requires_helper_token(defaults: Defaults, capsys: pytest.CaptureFixture[str]):
     event = {
         "issue": {"number": 280, "labels": [{"name": "wave:wave2"}]},
         "comment": {"body": "/orchestrate"},
@@ -78,29 +72,21 @@ def test_plan_requires_helper_token(
 def test_dispatch_round_trip(
     tmp_path: Path, defaults: Defaults, capsys: pytest.CaptureFixture[str]
 ):
-    prompt_path = (
-        defaults.project_root / "project" / "prompts" / "wave2" / "helper_prompt.md"
-    )
+    prompt_path = defaults.project_root / "project" / "prompts" / "wave2" / "helper_prompt.md"
     prompt_path.write_text("helper instructions", encoding="utf-8")
     event_path = tmp_path / "event.json"
     event = json.loads(
-        Path("tests/fixtures/github_issue_comment_wave2.json").read_text(
-            encoding="utf-8"
-        )
+        Path("tests/fixtures/github_issue_comment_wave2.json").read_text(encoding="utf-8")
     )
     event_path.write_text(json.dumps(event), encoding="utf-8")
 
     parser = _build_parser(defaults)
-    plan_args = parser.parse_args(
-        ["orchestrator", "plan", "--event-path", str(event_path)]
-    )
+    plan_args = parser.parse_args(["orchestrator", "plan", "--event-path", str(event_path)])
     assert run_orchestrator_command(plan_args, defaults) == 0
     plan_output = json.loads(capsys.readouterr().out)
     plan_path = plan_output["artifact_path"]
 
-    dispatch_args = parser.parse_args(
-        ["orchestrator", "dispatch", "--plan-path", plan_path]
-    )
+    dispatch_args = parser.parse_args(["orchestrator", "dispatch", "--plan-path", plan_path])
     assert run_orchestrator_command(dispatch_args, defaults) == 0
     dispatch_payload = json.loads(capsys.readouterr().out)
     assert dispatch_payload["plan"]["workflow_name"] == "orchestrator-runner"

--- a/tests/cli/test_rc_audit_pipeline.py
+++ b/tests/cli/test_rc_audit_pipeline.py
@@ -64,15 +64,11 @@ def test_run_audit_generates_expected_artifacts(defaults, fixtures_dir):
 
     golden_dir = Path(__file__).resolve().parents[1] / "fixtures" / "golden"
     generated_payload = json.loads(json_path.read_text(encoding="utf-8"))
-    golden_payload = json.loads(
-        (golden_dir / "audit_results.json").read_text(encoding="utf-8")
-    )
+    golden_payload = json.loads((golden_dir / "audit_results.json").read_text(encoding="utf-8"))
     assert generated_payload == golden_payload
 
     generated_summary = json.loads(summary_path.read_text(encoding="utf-8"))
-    golden_summary = json.loads(
-        (golden_dir / "summary.json").read_text(encoding="utf-8")
-    )
+    golden_summary = json.loads((golden_dir / "summary.json").read_text(encoding="utf-8"))
     assert generated_summary == golden_summary
 
     assert result.uploaded is False

--- a/tests/cli/test_rc_health.py
+++ b/tests/cli/test_rc_health.py
@@ -62,9 +62,7 @@ def _report(overall: str = "pass", dry_run: bool = False) -> ReadinessReport:
     )
 
 
-def test_health_readiness_prints_report(
-    monkeypatch: pytest.MonkeyPatch, defaults, capsys
-):
+def test_health_readiness_prints_report(monkeypatch: pytest.MonkeyPatch, defaults, capsys):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
@@ -83,9 +81,7 @@ def test_health_readiness_prints_report(
     assert payload["checks"]["s3"]["status"] == "pass"
 
 
-def test_health_readiness_writes_json(
-    monkeypatch: pytest.MonkeyPatch, defaults, tmp_path: Path
-):
+def test_health_readiness_writes_json(monkeypatch: pytest.MonkeyPatch, defaults, tmp_path: Path):
     output_path = tmp_path / "health.json"
 
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
@@ -139,9 +135,7 @@ def test_health_readiness_respects_overrides(monkeypatch: pytest.MonkeyPatch, de
     assert options.secrets["external/secret"] == "external/secret"
 
 
-def test_health_requires_readiness_flag(
-    monkeypatch: pytest.MonkeyPatch, defaults, capsys
-):
+def test_health_requires_readiness_flag(monkeypatch: pytest.MonkeyPatch, defaults, capsys):
     monkeypatch.setattr("src.cli.health.run_readiness", lambda options: _report())
 
     exit_code = app.main(["health"], defaults=defaults)

--- a/tests/config/test_secrets_loader.py
+++ b/tests/config/test_secrets_loader.py
@@ -21,16 +21,12 @@ class _FakeClient:
         self.response = response
         self.calls: list[str] = []
 
-    def get_secret_value(
-        self, SecretId: str
-    ) -> Dict[str, Any]:  # noqa: N803 - AWS casing
+    def get_secret_value(self, SecretId: str) -> Dict[str, Any]:  # noqa: N803 - AWS casing
         self.calls.append(SecretId)
         return dict(self.response)
 
 
-def _patch_boto3(
-    monkeypatch: pytest.MonkeyPatch, response: Dict[str, Any]
-) -> _FakeClient:
+def _patch_boto3(monkeypatch: pytest.MonkeyPatch, response: Dict[str, Any]) -> _FakeClient:
     client = _FakeClient(response)
     namespace = types.SimpleNamespace(client=lambda service: client)
     monkeypatch.setattr(secret_loader, "boto3", namespace)

--- a/tests/generator/test_archive.py
+++ b/tests/generator/test_archive.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-
 from zoneinfo import ZoneInfo
 
 from tools.generator.archive import PHOENIX_TZ, archive_previous_wave

--- a/tests/generator/test_drift_guard.py
+++ b/tests/generator/test_drift_guard.py
@@ -53,9 +53,7 @@ def _run_guard(cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_drift_guard_detects_changes(
-    generator_env: Path, sample_spec: dict[str, object]
-) -> None:
+def test_drift_guard_detects_changes(generator_env: Path, sample_spec: dict[str, object]) -> None:
     """The guard should fail when artifacts drift and pass once regenerated."""
 
     repo = generator_env
@@ -74,9 +72,7 @@ def test_drift_guard_detects_changes(
     manifest_path = repo / "artifacts/manifests" / f"wave{wave}_subprompts.json"
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     payload["timezone"] = "UTC"
-    manifest_path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     drift = _run_guard(repo)
     assert drift.returncode != 0

--- a/tests/generator/test_manifest.py
+++ b/tests/generator/test_manifest.py
@@ -20,9 +20,7 @@ def test_manifest_contains_expected_metadata(sample_spec: dict[str, object]) -> 
     assert payload["items"] == sorted(items, key=lambda item: item["slug"])
 
 
-def test_resolve_generated_at_reuses_manifest_timestamp(
-    sample_spec: dict[str, object]
-) -> None:
+def test_resolve_generated_at_reuses_manifest_timestamp(sample_spec: dict[str, object]) -> None:
     """`resolve_generated_at` should reuse Phoenix timestamps from disk."""
 
     items = generator.render_subprompts_and_issues(sample_spec)

--- a/tests/github/test_ci_watchdog.py
+++ b/tests/github/test_ci_watchdog.py
@@ -6,7 +6,6 @@ import pytest
 
 from scripts.github import ci_watchdog
 
-
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "github" / "watchdog"
 
 
@@ -68,9 +67,7 @@ def test_collect_failures_filters_and_sorts(monkeypatch):
     }
     freeze_utc_now(
         monkeypatch,
-        ci_watchdog._dt.datetime(
-            2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc
-        ),
+        ci_watchdog._dt.datetime(2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc),
     )
     mock_session(monkeypatch, mapping)
 
@@ -92,9 +89,7 @@ def test_collect_failures_skips_stale(monkeypatch):
     }
     freeze_utc_now(
         monkeypatch,
-        ci_watchdog._dt.datetime(
-            2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc
-        ),
+        ci_watchdog._dt.datetime(2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc),
     )
     mock_session(monkeypatch, mapping)
 
@@ -105,9 +100,7 @@ def test_collect_failures_skips_stale(monkeypatch):
 def test_render_report_matches_golden(monkeypatch, tmp_path):
     freeze_utc_now(
         monkeypatch,
-        ci_watchdog._dt.datetime(
-            2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc
-        ),
+        ci_watchdog._dt.datetime(2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc),
     )
 
     failure = ci_watchdog.PullRequestFailure(
@@ -127,9 +120,9 @@ def test_render_report_matches_golden(monkeypatch, tmp_path):
     )
 
     report = ci_watchdog.render_report([failure])
-    golden = (
-        Path(__file__).parent.parent / "golden" / "watchdog" / "report.md"
-    ).read_text(encoding="utf-8")
+    golden = (Path(__file__).parent.parent / "golden" / "watchdog" / "report.md").read_text(
+        encoding="utf-8"
+    )
     assert report == golden
 
 

--- a/tests/github/test_wave2_helper.py
+++ b/tests/github/test_wave2_helper.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from releasecopilot.logging_config import get_logger
-
 from scripts.github.wave2_helper import (
     Issue,
     Wave2Helper,
@@ -35,9 +34,7 @@ def fixture_issues() -> list[Issue]:
     return [Issue.from_raw(item) for item in data]
 
 
-def test_prioritize_is_deterministic(
-    helper: Wave2Helper, fixture_issues: list[Issue]
-) -> None:
+def test_prioritize_is_deterministic(helper: Wave2Helper, fixture_issues: list[Issue]) -> None:
     filtered = helper.filter_issues(fixture_issues)
     numbers = [issue.number for issue in filtered]
     assert 310 not in numbers  # filtered out by label guard
@@ -110,4 +107,4 @@ def test_collect_uses_gh_without_leaking_token(
 
     helper_logger = get_logger("scripts.github.wave2_helper.test")
     helper_logger.info("verifying redaction", extra={"token": "supersecret-token"})
-    assert getattr(caplog.records[-1], "token") == "***REDACTED***"
+    assert caplog.records[-1].token == "***REDACTED***"

--- a/tests/infra/test_budget_alerts.py
+++ b/tests/infra/test_budget_alerts.py
@@ -9,7 +9,6 @@ from aws_cdk.assertions import Match, Template
 
 from infra.cdk.core_stack import CoreStack
 
-
 ACCOUNT = "123456789012"
 REGION = "us-west-2"
 ASSET_DIR = str(Path(__file__).resolve().parents[2] / "dist")
@@ -26,9 +25,7 @@ def _synth_template(**overrides) -> Template:
         environment_name=overrides.pop("environment_name", "dev"),
         budget_amount=overrides.pop("budget_amount", 275.0),
         budget_currency=overrides.pop("budget_currency", "USD"),
-        budget_email_recipients=overrides.pop(
-            "budget_email_recipients", ["alerts@example.com"]
-        ),
+        budget_email_recipients=overrides.pop("budget_email_recipients", ["alerts@example.com"]),
         **overrides,
     )
     return Template.from_stack(stack)
@@ -42,10 +39,7 @@ def test_budget_notifications_configured() -> None:
 
     budget = next(iter(template.find_resources("AWS::Budgets::Budget").values()))
 
-    assert (
-        budget["Properties"]["Budget"]["BudgetName"]
-        == "releasecopilot-dev-monthly-cost"
-    )
+    assert budget["Properties"]["Budget"]["BudgetName"] == "releasecopilot-dev-monthly-cost"
 
     notifications = budget["Properties"]["NotificationsWithSubscribers"]
     assert len(notifications) == 3

--- a/tests/ops/test_ci_watchdog_cli.py
+++ b/tests/ops/test_ci_watchdog_cli.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from scripts.github import ci_watchdog
-
 from tests.github.test_ci_watchdog import freeze_utc_now, load_fixture, mock_session
 
 
@@ -17,9 +16,7 @@ def test_cli_generates_artifacts(monkeypatch, tmp_path):
 
     freeze_utc_now(
         monkeypatch,
-        ci_watchdog._dt.datetime(
-            2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc
-        ),
+        ci_watchdog._dt.datetime(2024, 5, 1, 14, 0, tzinfo=ci_watchdog._dt.timezone.utc),
     )
     mock_session(monkeypatch, mapping)
 

--- a/tests/ops/test_helper_cli.py
+++ b/tests/ops/test_helper_cli.py
@@ -32,9 +32,7 @@ def test_cli_pipeline_generates_artifacts(tmp_path: Path) -> None:
     assert result_collect.exit_code == 0, result_collect.output
 
     config_payload = yaml.safe_load(config_path.read_text())
-    artifact_dirs = {
-        key: Path(value) for key, value in config_payload["artifact_dirs"].items()
-    }
+    artifact_dirs = {key: Path(value) for key, value in config_payload["artifact_dirs"].items()}
 
     collected_path = artifact_dirs["collected_issues"]
     assert collected_path.exists()
@@ -67,9 +65,7 @@ def test_cli_pipeline_generates_artifacts(tmp_path: Path) -> None:
 
     activity_path = artifact_dirs["activity_log"]
     entries = [
-        json.loads(line)
-        for line in activity_path.read_text(encoding="utf-8").splitlines()
-        if line
+        json.loads(line) for line in activity_path.read_text(encoding="utf-8").splitlines() if line
     ]
     assert {entry["command"] for entry in entries} >= {
         "collect",

--- a/tests/promptops/test_human_actions.py
+++ b/tests/promptops/test_human_actions.py
@@ -118,9 +118,7 @@ def test_generate_human_actions_with_empty_issues(tmp_path: Path) -> None:
     checklist_text = (output_dir / "checklist.md").read_text(encoding="utf-8")
     assert "No prioritized issues supplied" in checklist_text
 
-    calendar_payload = json.loads(
-        (output_dir / "calendar.json").read_text(encoding="utf-8")
-    )
+    calendar_payload = json.loads((output_dir / "calendar.json").read_text(encoding="utf-8"))
     assert "stub" in calendar_payload["ical"]
     assert metadata.run_hash in calendar_payload["ical"]
 

--- a/tests/services/test_jira_reconciliation_job_idempotency.py
+++ b/tests/services/test_jira_reconciliation_job_idempotency.py
@@ -50,9 +50,7 @@ def test_reconciliation_skips_stale_and_marks_deletes(
         {"issue_key": "MOB-2", "updated_at": "2024-01-01T00:00:00Z", "deleted": False},
     ]
 
-    monkeypatch.setattr(
-        handler, "_query_fix_version", lambda fix_version: existing_items
-    )
+    monkeypatch.setattr(handler, "_query_fix_version", lambda fix_version: existing_items)
 
     created: List[Dict[str, Any]] = []
     deleted: List[str] = []

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.config.loader import load_config
-
 from tests.helpers_config import StubCredentialStore, write_defaults
 
 

--- a/tests/test_config_precedence.py
+++ b/tests/test_config_precedence.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 
 from src.config.loader import ConfigurationError, load_config
-
 from tests.helpers_config import StubCredentialStore, write_defaults
 
 
@@ -44,9 +43,7 @@ def test_missing_required_values_raise(tmp_path: Path) -> None:
 
 def test_environment_overrides_secret_values(tmp_path: Path) -> None:
     defaults = write_defaults(tmp_path)
-    secrets = StubCredentialStore(
-        {"arn:example:jira": {"client_secret": "secret-value"}}
-    )
+    secrets = StubCredentialStore({"arn:example:jira": {"client_secret": "secret-value"}})
     env = {"JIRA_CLIENT_SECRET": "env-value"}
 
     config = load_config(

--- a/tests/test_core_infra_stack.py
+++ b/tests/test_core_infra_stack.py
@@ -7,7 +7,6 @@ from aws_cdk.assertions import Match, Template
 
 from infra.cdk.core_stack import CoreStack
 
-
 ACCOUNT = "123456789012"
 REGION = "us-west-2"
 ASSET_DIR = str(Path(__file__).resolve().parents[1] / "dist")
@@ -167,9 +166,7 @@ def test_eventbridge_rule_targets_lambda_when_enabled() -> None:
             "JiraReconciliationLambda"
         )
     )
-    assert (
-        reconciliation_rule["Properties"]["ScheduleExpression"] == "cron(15 7 * * ? *)"
-    )
+    assert reconciliation_rule["Properties"]["ScheduleExpression"] == "cron(15 7 * * ? *)"
 
 
 def test_eventbridge_rule_not_created_when_disabled() -> None:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -57,12 +57,8 @@ def test_diff_runs_returns_sorted_changes() -> None:
 
     assert diff["stories_added"] == ["STORY-3"]
     assert diff["stories_removed"] == ["STORY-2"]
-    assert diff["status_changes"] == [
-        {"key": "STORY-1", "from": "In Progress", "to": "Done"}
-    ]
-    assert diff["assignee_changes"] == [
-        {"key": "STORY-1", "from": "Alice", "to": "Charlie"}
-    ]
+    assert diff["status_changes"] == [{"key": "STORY-1", "from": "In Progress", "to": "Done"}]
+    assert diff["assignee_changes"] == [{"key": "STORY-1", "from": "Alice", "to": "Charlie"}]
     assert diff["commits_added"] == [
         {"key": "STORY-1", "commit_ids": ["b2"]},
         {"key": "STORY-3", "commit_ids": ["c3"]},

--- a/tests/test_dotenv_precedence.py
+++ b/tests/test_dotenv_precedence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-import sys
+import importlib
 from pathlib import Path
 
 import pytest
@@ -31,9 +31,8 @@ def test_cli_prefers_cli_then_env_then_yaml(
         monkeypatch.delenv(key, raising=False)
 
     try:
-        sys.modules.pop("releasecopilot", None)
-        sys.modules.pop("releasecopilot.cli", None)
-        import releasecopilot.cli as cli_module  # noqa: WPS433
+        cli_module = importlib.import_module("releasecopilot.cli")
+        cli_module = importlib.reload(cli_module)
 
         assert cli_module.load_dotenv is not None
         assert cli_module.find_dotenv_path() == env_path
@@ -73,8 +72,7 @@ def test_cli_prefers_cli_then_env_then_yaml(
         assert config["jira_base"] == "https://cli-jira"
         assert config["bitbucket_base"] == "https://dotenv-bitbucket"
     finally:
-        sys.modules.pop("releasecopilot", None)
-        sys.modules.pop("releasecopilot.cli", None)
+        importlib.reload(cli_module)
         if existing_env is None:
             env_path.unlink(missing_ok=True)
         else:

--- a/tests/test_exporter_golden.py
+++ b/tests/test_exporter_golden.py
@@ -8,9 +8,7 @@ from pathlib import Path
 from exporters.json_exporter import JSONExporter
 
 
-def test_json_exporter_produces_expected_payload(
-    tmp_path, fixtures_dir, load_json
-) -> None:
+def test_json_exporter_produces_expected_payload(tmp_path, fixtures_dir, load_json) -> None:
     """Exported JSON should match the golden artifact byte-for-byte."""
 
     payload = {

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import sys
 from types import ModuleType
 
 import pytest
@@ -11,10 +10,8 @@ import pytest
 def _reload_logging(monkeypatch: pytest.MonkeyPatch, **env: str) -> ModuleType:
     for key, value in env.items():
         monkeypatch.setenv(key, value)
-    for name in list(sys.modules):
-        if name.startswith("releasecopilot"):
-            sys.modules.pop(name)
-    return importlib.import_module("releasecopilot.logging_config")
+    module = importlib.import_module("releasecopilot.logging_config")
+    return importlib.reload(module)
 
 
 def test_structured_logging_includes_correlation_id(
@@ -56,9 +53,7 @@ def test_secret_redaction(
     logging_module.configure_logging("DEBUG")
     logger = logging_module.get_logger("redact.logger")
 
-    logger.debug(
-        "token value", extra={"api_token": "abc123", "nested": {"secret": "shhh"}}
-    )
+    logger.debug("token value", extra={"api_token": "abc123", "nested": {"secret": "shhh"}})
 
     output = capsys.readouterr().out
     assert "***REDACTED***" in output

--- a/tests/test_recover_and_export.py
+++ b/tests/test_recover_and_export.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-
 FIXTURE_DIR = Path("tests/fixtures/temp_data")
 GOLDEN_DIR = Path("tests/fixtures/golden")
 EXPECTED_WORKBOOK = GOLDEN_DIR / "audit_results_workbook.json"

--- a/tests/test_wave_generator.py
+++ b/tests/test_wave_generator.py
@@ -37,9 +37,7 @@ def test_subprompts_render(sample_spec: dict) -> None:
     items = generator.render_subprompts_and_issues(sample_spec)
     assert len(items) == len(sample_spec["sequenced_prs"])
     subprompt_path = Path(items[0]["subprompt_path"])
-    assert subprompt_path.read_text(encoding="utf-8").startswith(
-        "# Wave 3 – Sub-Prompt"
-    )
+    assert subprompt_path.read_text(encoding="utf-8").startswith("# Wave 3 – Sub-Prompt")
 
 
 def test_manifest_schema(sample_spec: dict) -> None:
@@ -55,9 +53,7 @@ def test_idempotent_outputs(sample_spec: dict) -> None:
     first_items = generator.render_subprompts_and_issues(sample_spec)
     first_manifest = generator.write_manifest(sample_spec["wave"], first_items)
     first_hashes = {
-        "mop": hashlib.sha256(
-            generator.render_mop_from_yaml(sample_spec).read_bytes()
-        ).hexdigest(),
+        "mop": hashlib.sha256(generator.render_mop_from_yaml(sample_spec).read_bytes()).hexdigest(),
         "subprompt": hashlib.sha256(
             Path(first_items[0]["subprompt_path"]).read_bytes()
         ).hexdigest(),
@@ -67,16 +63,11 @@ def test_idempotent_outputs(sample_spec: dict) -> None:
     second_manifest = generator.write_manifest(sample_spec["wave"], second_items)
     assert first_items == second_items
     assert (
-        hashlib.sha256(
-            generator.render_mop_from_yaml(sample_spec).read_bytes()
-        ).hexdigest()
+        hashlib.sha256(generator.render_mop_from_yaml(sample_spec).read_bytes()).hexdigest()
         == first_hashes["mop"]
     )
     assert (
         hashlib.sha256(Path(second_items[0]["subprompt_path"]).read_bytes()).hexdigest()
         == first_hashes["subprompt"]
     )
-    assert (
-        hashlib.sha256(second_manifest.read_bytes()).hexdigest()
-        == first_hashes["manifest"]
-    )
+    assert hashlib.sha256(second_manifest.read_bytes()).hexdigest() == first_hashes["manifest"]

--- a/tests/tools/test_render_actions_comment.py
+++ b/tests/tools/test_render_actions_comment.py
@@ -11,9 +11,7 @@ from tools import render_actions_comment
 
 @pytest.fixture(autouse=True)
 def _freeze_git_sha(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        render_actions_comment, "resolve_git_sha", lambda explicit: "test-sha"
-    )
+    monkeypatch.setattr(render_actions_comment, "resolve_git_sha", lambda explicit: "test-sha")
 
 
 def test_build_comment_with_actions() -> None:
@@ -30,9 +28,7 @@ def test_build_comment_with_actions() -> None:
             labels=["human-action", "wave:1"],
         )
     ]
-    body = render_actions_comment.build_comment(
-        actions, actions, pr_number=2, git_sha="abc123"
-    )
+    body = render_actions_comment.build_comment(actions, actions, pr_number=2, git_sha="abc123")
     assert "Approve" in body
     assert "infra/file.py" in body
     assert "⚠️ Outstanding Human Actions" in body
@@ -40,9 +36,7 @@ def test_build_comment_with_actions() -> None:
 
 def test_build_comment_without_matching_actions() -> None:
     actions: List[render_actions_comment.PendingAction] = []
-    body = render_actions_comment.build_comment(
-        actions, actions, pr_number=5, git_sha="abc123"
-    )
+    body = render_actions_comment.build_comment(actions, actions, pr_number=5, git_sha="abc123")
     assert "No outstanding human actions" in body
 
 
@@ -88,9 +82,7 @@ def test_main_updates_comment(
 
     calls: List[Dict[str, Any]] = []
 
-    def fake_request(
-        method: str, url: str, token: str, data: Dict[str, Any] | None = None
-    ) -> Any:
+    def fake_request(method: str, url: str, token: str, data: Dict[str, Any] | None = None) -> Any:
         calls.append({"method": method, "url": url, "data": data})
         if method == "GET":
             return [
@@ -116,9 +108,7 @@ def test_main_updates_comment(
     assert exit_code == 0
     assert any(call["method"] == "PATCH" for call in calls)
     label_call = next(
-        call
-        for call in calls
-        if call["method"] == "POST" and call["url"].endswith("/labels")
+        call for call in calls if call["method"] == "POST" and call["url"].endswith("/labels")
     )
     assert sorted(label_call["data"]["labels"]) == ["human-action", "wave:1"]
     patch_call = next(call for call in calls if call["method"] == "PATCH")
@@ -127,9 +117,7 @@ def test_main_updates_comment(
     assert "test-sha" in captured.out
 
 
-def test_main_creates_comment_when_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_creates_comment_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     actions_path = tmp_path / "actions.json"
     actions_path.write_text("[]", encoding="utf-8")
     event_path = tmp_path / "event.json"
@@ -140,9 +128,7 @@ def test_main_creates_comment_when_missing(
 
     calls: List[Dict[str, Any]] = []
 
-    def fake_request(
-        method: str, url: str, token: str, data: Dict[str, Any] | None = None
-    ) -> Any:
+    def fake_request(method: str, url: str, token: str, data: Dict[str, Any] | None = None) -> Any:
         calls.append({"method": method, "url": url, "data": data})
         if method == "GET":
             return []
@@ -160,6 +146,4 @@ def test_main_creates_comment_when_missing(
     )
 
     assert exit_code == 0
-    assert any(
-        call["method"] == "POST" and "/comments" in call["url"] for call in calls
-    )
+    assert any(call["method"] == "POST" and "/comments" in call["url"] for call in calls)

--- a/tests/tools/test_validate_prompts.py
+++ b/tests/tools/test_validate_prompts.py
@@ -10,9 +10,7 @@ from tools import validate_prompts
 
 @pytest.fixture(autouse=True)
 def _freeze_git_sha(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        validate_prompts, "resolve_git_sha", lambda explicit: "test-sha"
-    )
+    monkeypatch.setattr(validate_prompts, "resolve_git_sha", lambda explicit: "test-sha")
 
 
 def test_missing_recipe_fails(
@@ -67,9 +65,7 @@ def test_missing_recipe_with_relative_paths(
     assert "prompts/task.md" in captured.err
 
 
-def test_validator_passes_with_recipe(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_validator_passes_with_recipe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     prompts_dir = tmp_path / "prompts"
     prompts_dir.mkdir()
@@ -136,9 +132,7 @@ def test_validator_passes_with_relative_paths(
     assert exit_code == 0
 
 
-def test_auto_discovers_wave_directories(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_auto_discovers_wave_directories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     prompts_root = Path("project") / "prompts"
     wave_dir = prompts_root / "wave5"
@@ -212,9 +206,7 @@ def test_wave_argument_limits_directories(
     assert "wave3" not in captured.out
 
 
-def test_config_file_drives_discovery(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_file_drives_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     prompts_root = Path("project") / "prompts"
     active_wave = prompts_root / "wave9"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.config.loader import load_config
-
 from tests.helpers_config import StubCredentialStore, write_defaults
 
 

--- a/tests/unit/test_generate_history_collectors.py
+++ b/tests/unit/test_generate_history_collectors.py
@@ -22,18 +22,14 @@ def test_collect_project_section_prefers_projects() -> None:
     data = load_fixture("projects_v2_items.json")
 
     class FakeProjectsClient:
-        def query_issues_with_status(
-            self, owner, repo, project_name, status_field, status_values
-        ):
+        def query_issues_with_status(self, owner, repo, project_name, status_field, status_values):
             return [ProjectStatusItem(**item) for item in data["items"]]
 
     class RejectingRestClient:
         def list_open_issues_with_label(
             self, label: str
         ):  # pragma: no cover - should not be called
-            raise AssertionError(
-                "label fallback should not run when projects data is available"
-            )
+            raise AssertionError("label fallback should not run when projects data is available")
 
     result = generate_history._collect_project_section(  # type: ignore[attr-defined]
         owner="org",
@@ -100,16 +96,10 @@ def test_collect_notes_section_aggregates_markers(
             return data["review_comments"]
 
         def get_issue(self, number: int):  # pragma: no cover - not used in this test
-            raise AssertionError(
-                "get_issue should not be called when mirroring disabled"
-            )
+            raise AssertionError("get_issue should not be called when mirroring disabled")
 
-    monkeypatch.setattr(
-        generate_history, "_collect_local_notes", lambda root, since: []
-    )
-    monkeypatch.setattr(
-        generate_history, "_collect_jira_references", lambda root, since: []
-    )
+    monkeypatch.setattr(generate_history, "_collect_local_notes", lambda root, since: [])
+    monkeypatch.setattr(generate_history, "_collect_jira_references", lambda root, since: [])
 
     since = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
     until = dt.datetime(2024, 1, 7, tzinfo=dt.timezone.utc)
@@ -315,12 +305,8 @@ def test_notes_mirroring_writes_deduplicated_files(
                 "html_url": f"https://github.com/org/repo/issues/{number}",
             }
 
-    monkeypatch.setattr(
-        generate_history, "_collect_local_notes", lambda root, since: []
-    )
-    monkeypatch.setattr(
-        generate_history, "_collect_jira_references", lambda root, since: []
-    )
+    monkeypatch.setattr(generate_history, "_collect_local_notes", lambda root, since: [])
+    monkeypatch.setattr(generate_history, "_collect_jira_references", lambda root, since: [])
 
     since = dt.datetime(2024, 1, 25, tzinfo=dt.timezone.utc)
     until = dt.datetime(2024, 2, 2, tzinfo=dt.timezone.utc)

--- a/tests/unit/test_jira_issue_store.py
+++ b/tests/unit/test_jira_issue_store.py
@@ -13,9 +13,7 @@ class FakeTable:
         self.pages = list(pages)
         self.calls: List[Dict[str, Any]] = []
 
-    def query(
-        self, **kwargs: Any
-    ) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+    def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
         self.calls.append(kwargs)
         if not self.pages:
             return {"Items": []}
@@ -88,9 +86,7 @@ def test_fetch_issues_retries_on_throttle(monkeypatch: pytest.MonkeyPatch) -> No
             super().__init__([{"Items": []}])
             self.failures = 0
 
-        def query(
-            self, **kwargs: Any
-        ) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+        def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
             self.calls.append(kwargs)
             if self.failures < 2:
                 self.failures += 1
@@ -119,9 +115,7 @@ def test_fetch_issues_raises_on_non_retryable_error(
     )
 
     class BrokenTable(FakeTable):
-        def query(
-            self, **kwargs: Any
-        ) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+        def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
             self.calls.append(kwargs)
             raise error
 

--- a/tests/unit/test_jira_reconciliation_handler.py
+++ b/tests/unit/test_jira_reconciliation_handler.py
@@ -20,9 +20,7 @@ def _reset_module(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
     monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
-    module = importlib.reload(
-        importlib.import_module("services.jira_reconciliation_job.handler")
-    )
+    module = importlib.reload(importlib.import_module("services.jira_reconciliation_job.handler"))
     monkeypatch.setitem(
         module.__dict__,
         "_SECRET_CACHE",
@@ -39,20 +37,14 @@ class DummyTable:
         self.update_calls: List[Dict[str, Any]] = []
         self.scan_calls = 0
 
-    def query(
-        self, **kwargs: Any
-    ) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+    def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
         return {"Items": list(self.items)}
 
-    def scan(
-        self, **kwargs: Any
-    ) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+    def scan(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
         self.scan_calls += 1
         return {"Items": [{"fix_version": "2024.05"}], "LastEvaluatedKey": None}
 
-    def put_item(
-        self, **kwargs: Any
-    ) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+    def put_item(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
         self.put_calls.append(kwargs)
         self.items.append(kwargs.get("Item", {}))
         return {}

--- a/tests/unit/test_jira_webhook_handler.py
+++ b/tests/unit/test_jira_webhook_handler.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import importlib
 import json
 import os
-import importlib
 from typing import Any, Dict, List
 
 import pytest
@@ -21,14 +21,10 @@ class DummyTable:
     def put_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
         self.items.append(kwargs)
 
-    def update_item(
-        self, **kwargs: Any
-    ) -> None:  # pragma: no cover - exercised in tests
+    def update_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
         self.updated.append(kwargs)
 
-    def query(
-        self, **kwargs: Any
-    ) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
+    def query(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - exercised in tests
         return {"Items": []}
 
 
@@ -45,9 +41,7 @@ def _patch_table(monkeypatch: pytest.MonkeyPatch) -> DummyTable:
     return table
 
 
-def _build_event(
-    body: Dict[str, Any], headers: Dict[str, str] | None = None
-) -> Dict[str, Any]:
+def _build_event(body: Dict[str, Any], headers: Dict[str, str] | None = None) -> Dict[str, Any]:
     return {
         "httpMethod": "POST",
         "headers": headers or {},
@@ -91,9 +85,7 @@ def test_upsert_event_persists_issue(
     assert item["Item"]["issue_key"] == "ABC-1"
     assert item["Item"]["fix_version"] == "2024.05"
     assert item["Item"]["idempotency_key"].startswith("ABC-1")
-    assert item["ConditionExpression"].startswith(
-        "attribute_not_exists(idempotency_key)"
-    )
+    assert item["ConditionExpression"].startswith("attribute_not_exists(idempotency_key)")
 
 
 def test_delete_event_removes_issue(
@@ -116,9 +108,7 @@ def test_delete_event_removes_issue(
 def test_rejects_invalid_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("WEBHOOK_SECRET", "expected")
     monkeypatch.setitem(webhook_handler.__dict__, "WEBHOOK_SECRET", "expected")
-    event = _build_event(
-        {"webhookEvent": "jira:issue_created", "issue": {"id": "1", "key": "A"}}
-    )
+    event = _build_event({"webhookEvent": "jira:issue_created", "issue": {"id": "1", "key": "A"}})
     response = webhook_handler.handler(event, None)
     assert response["statusCode"] == 401
 
@@ -131,17 +121,13 @@ def test_conditional_failure_is_ignored(
             super().__init__()
             self.called = False
 
-        def put_item(
-            self, **kwargs: Any
-        ) -> None:  # pragma: no cover - exercised in tests
+        def put_item(self, **kwargs: Any) -> None:  # pragma: no cover - exercised in tests
             if not self.called:
                 self.called = True
                 from botocore.exceptions import ClientError
 
                 raise ClientError(
-                    error_response={
-                        "Error": {"Code": "ConditionalCheckFailedException"}
-                    },
+                    error_response={"Error": {"Code": "ConditionalCheckFailedException"}},
                     operation_name="PutItem",
                 )
             super().put_item(**kwargs)

--- a/tests/unit/tracking/test_diff.py
+++ b/tests/unit/tracking/test_diff.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from tracking import api as tracking_api
 from tracking.diff import diff_runs, render_diff_markdown
 

--- a/tests/unit/ui/test_transform.py
+++ b/tests/unit/ui/test_transform.py
@@ -30,9 +30,7 @@ def test_filters_by_fix_version_and_repository() -> None:
     with_df, without_df = transform.prepare_story_tables(report)
 
     filters = {"fix_versions": ["MOB-1.1.0"]}
-    filtered_with, filtered_without = transform.filter_story_tables(
-        with_df, without_df, filters
-    )
+    filtered_with, filtered_without = transform.filter_story_tables(with_df, without_df, filters)
 
     assert filtered_with["story_key"].tolist() == ["APP-3"]
     assert filtered_without.empty

--- a/tools/generator/archive.py
+++ b/tools/generator/archive.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Final
-
 from zoneinfo import ZoneInfo
 
 PHOENIX_TZ: Final[str] = "America/Phoenix"

--- a/tools/generator/generator.py
+++ b/tools/generator/generator.py
@@ -9,13 +9,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Final, Iterable, Mapping
+from zoneinfo import ZoneInfo
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from slugify import slugify
-from zoneinfo import ZoneInfo
 
-from .archive import ArchiveResult, archive_previous_wave, PHOENIX_TZ as ARCHIVE_TZ
+from .archive import PHOENIX_TZ as ARCHIVE_TZ
+from .archive import ArchiveResult, archive_previous_wave
 
 PHOENIX_TZ: Final[str] = ARCHIVE_TZ
 
@@ -293,9 +294,7 @@ def generate_from_yaml(
     spec = load_spec(spec_path)
     now_provider = now or (lambda: zoned_now(timezone))
     current_dt = now_provider()
-    generated_at = resolve_generated_at(
-        spec["wave"], base_dir=root, fallback=current_dt
-    )
+    generated_at = resolve_generated_at(spec["wave"], base_dir=root, fallback=current_dt)
     label = format_timezone_label(timezone)
 
     archive_result: ArchiveResult | None = None

--- a/tools/render_actions_comment.py
+++ b/tools/render_actions_comment.py
@@ -15,7 +15,6 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 from zoneinfo import ZoneInfo
 
-
 PHOENIX_TZ = ZoneInfo("America/Phoenix")
 COMMENT_MARKER = "<!-- actions-comment -->"
 COMMENT_TITLE = "⚠️ Outstanding Human Actions"
@@ -81,9 +80,7 @@ def extract_pr_number(event: dict) -> int:
         raise ValueError("Pull request number missing from event payload") from exc
 
 
-def filter_actions(
-    actions: Iterable[PendingAction], pr_number: int
-) -> List[PendingAction]:
+def filter_actions(actions: Iterable[PendingAction], pr_number: int) -> List[PendingAction]:
     needle = f"#{pr_number}"
     return [action for action in actions if action.pr == needle]
 
@@ -119,9 +116,7 @@ def build_comment(
     return body
 
 
-def github_request(
-    method: str, url: str, token: str, data: Optional[dict] = None
-) -> dict:
+def github_request(method: str, url: str, token: str, data: Optional[dict] = None) -> dict:
     payload: Optional[bytes] = None
     if data is not None:
         payload = json.dumps(data).encode("utf-8")
@@ -163,9 +158,7 @@ def sync_comment(token: str, repo: str, pr_number: int, body: str) -> None:
         github_request("POST", comments_url, token, {"body": body})
 
 
-def sync_labels(
-    token: str, repo: str, pr_number: int, actions: Iterable[PendingAction]
-) -> None:
+def sync_labels(token: str, repo: str, pr_number: int, actions: Iterable[PendingAction]) -> None:
     labels: List[str] = []
     for item in actions:
         for label in item.labels:
@@ -228,9 +221,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "git_sha": git_sha,
         "actions_path": str(args.actions_path),
         "pr_number": pr_number,
-        "applied_labels": sorted(
-            {label for action in pr_actions for label in action.labels}
-        ),
+        "applied_labels": sorted({label for action in pr_actions for label in action.labels}),
         "cli_args": sys.argv[1:],
     }
     print(json.dumps(metadata, indent=2))

--- a/tools/validate_prompts.py
+++ b/tools/validate_prompts.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Dict, List, Sequence
 from zoneinfo import ZoneInfo
 
-
 PHOENIX_TZ = ZoneInfo("America/Phoenix")
 
 
@@ -67,9 +66,7 @@ class PromptRecipeValidator:
         missing: List[str] = []
         repo_root = Path.cwd().resolve()
         for prompt in prompts:
-            prompt_path = (
-                prompt if prompt.is_absolute() else (repo_root / prompt).resolve()
-            )
+            prompt_path = prompt if prompt.is_absolute() else (repo_root / prompt).resolve()
             try:
                 key = str(prompt_path.relative_to(repo_root))
             except ValueError:
@@ -178,8 +175,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     if not prompt_dirs:
         print(
-            "No prompt directories discovered. Use --prompts-dir or --waves to"
-            " specify targets.",
+            "No prompt directories discovered. Use --prompts-dir or --waves to" " specify targets.",
             file=sys.stderr,
         )
         return 1
@@ -187,8 +183,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     missing_dirs = [str(path) for path in prompt_dirs if not path.exists()]
     if missing_dirs:
         print(
-            "Prompt directories not found:\n"
-            + "\n".join(f" - {item}" for item in missing_dirs),
+            "Prompt directories not found:\n" + "\n".join(f" - {item}" for item in missing_dirs),
             file=sys.stderr,
         )
         return 1
@@ -212,18 +207,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     if missing:
         print(
-            "Missing prompt recipes for:"
-            + "\n"
-            + "\n".join(f" - {item}" for item in missing),
+            "Missing prompt recipes for:" + "\n" + "\n".join(f" - {item}" for item in missing),
             file=sys.stderr,
         )
         return 1
     return 0
 
 
-def _load_configured_dirs(
-    *, config_path: Path, prompts_root: Path
-) -> tuple[List[Path], List[str]]:
+def _load_configured_dirs(*, config_path: Path, prompts_root: Path) -> tuple[List[Path], List[str]]:
     if not config_path or not config_path.exists():
         return [], []
 

--- a/ui/data_source.py
+++ b/ui/data_source.py
@@ -91,9 +91,7 @@ def load_s3_listing(bucket: str, prefix: str = "") -> List[RunRef]:
                 elif key.lower().endswith((".xlsx", ".xlsm")):
                     entry["excel"] = key
     except (ClientError, BotoCoreError) as exc:  # pragma: no cover - passthrough
-        raise RuntimeError(
-            f"Unable to list objects in s3://{bucket}/{prefix}: {exc}"
-        ) from exc
+        raise RuntimeError(f"Unable to list objects in s3://{bucket}/{prefix}: {exc}") from exc
 
     run_refs = [
         RunRef(

--- a/ui/transform.py
+++ b/ui/transform.py
@@ -47,11 +47,7 @@ def prepare_story_tables(report: Dict[str, Any]) -> Tuple[pd.DataFrame, pd.DataF
     with_rows: List[Dict[str, Any]] = []
     for entry in report.get("commit_story_mapping", []):
         commits = entry.get("commits", [])
-        dates = [
-            pd.to_datetime(commit.get("date"))
-            for commit in commits
-            if commit.get("date")
-        ]
+        dates = [pd.to_datetime(commit.get("date")) for commit in commits if commit.get("date")]
         with_rows.append(
             {
                 "story_key": entry.get("story_key"),
@@ -67,11 +63,7 @@ def prepare_story_tables(report: Dict[str, Any]) -> Tuple[pd.DataFrame, pd.DataF
                 "labels": _ensure_list(entry.get("labels")),
                 "all_labels": _collect_labels(entry),
                 "repositories": sorted(
-                    {
-                        commit.get("repository")
-                        for commit in commits
-                        if commit.get("repository")
-                    }
+                    {commit.get("repository") for commit in commits if commit.get("repository")}
                 ),
                 "branches": sorted(
                     {commit.get("branch") for commit in commits if commit.get("branch")}
@@ -133,16 +125,12 @@ def build_orphan_dataframe(report: Dict[str, Any]) -> pd.DataFrame:
                 "hash": commit.get("hash"),
                 "message": commit.get("message"),
                 "author": commit.get("author"),
-                "date": (
-                    pd.to_datetime(commit.get("date")) if commit.get("date") else pd.NaT
-                ),
+                "date": (pd.to_datetime(commit.get("date")) if commit.get("date") else pd.NaT),
                 "repository": commit.get("repository"),
                 "branch": commit.get("branch"),
             }
         )
-    return pd.DataFrame(
-        rows, columns=["hash", "message", "author", "date", "repository", "branch"]
-    )
+    return pd.DataFrame(rows, columns=["hash", "message", "author", "date", "repository", "branch"])
 
 
 def filter_story_tables(
@@ -157,9 +145,7 @@ def filter_story_tables(
     return filtered_with, filtered_without
 
 
-def filter_orphan_commits(
-    orphan_df: pd.DataFrame, filters: StoryFilters
-) -> pd.DataFrame:
+def filter_orphan_commits(orphan_df: pd.DataFrame, filters: StoryFilters) -> pd.DataFrame:
     """Apply filters to the orphan commits table."""
 
     if orphan_df.empty:
@@ -192,9 +178,7 @@ def get_filter_options(
 ) -> Dict[str, Sequence[Any]]:
     """Collect filter options from the loaded data."""
 
-    combined = pd.concat(
-        [stories_with_commits, stories_without_commits], ignore_index=True
-    )
+    combined = pd.concat([stories_with_commits, stories_without_commits], ignore_index=True)
 
     fix_versions = sorted(
         {
@@ -254,9 +238,7 @@ def get_filter_options(
         "repositories": repositories,
         "branches": branches,
         "date_range": (
-            (date_min, date_max)
-            if date_min is not pd.NaT and date_max is not pd.NaT
-            else None
+            (date_min, date_max) if date_min is not pd.NaT and date_max is not pd.NaT else None
         ),
     }
 
@@ -270,9 +252,7 @@ def _apply_story_filters(df: pd.DataFrame, filters: StoryFilters) -> pd.DataFram
     fix_versions = filters.get("fix_versions")
     if fix_versions:
         result = result[
-            result["fix_versions"].apply(
-                lambda items: _contains_any(items, fix_versions)
-            )
+            result["fix_versions"].apply(lambda items: _contains_any(items, fix_versions))
         ]
 
     statuses = filters.get("statuses")
@@ -285,31 +265,24 @@ def _apply_story_filters(df: pd.DataFrame, filters: StoryFilters) -> pd.DataFram
 
     labels = filters.get("components_labels")
     if labels:
-        result = result[
-            result["all_labels"].apply(lambda items: _contains_any(items, labels))
-        ]
+        result = result[result["all_labels"].apply(lambda items: _contains_any(items, labels))]
 
     repositories = filters.get("repositories")
     if repositories:
         result = result[
-            result["repositories"].apply(
-                lambda items: _contains_any(items, repositories)
-            )
+            result["repositories"].apply(lambda items: _contains_any(items, repositories))
         ]
 
     branches = filters.get("branches")
     if branches:
-        result = result[
-            result["branches"].apply(lambda items: _contains_any(items, branches))
-        ]
+        result = result[result["branches"].apply(lambda items: _contains_any(items, branches))]
 
     date_range = filters.get("date_range")
     if date_range:
         start, end = date_range
         if start is not None:
             result = result[
-                result["latest_commit_date"].notna()
-                & (result["latest_commit_date"] >= start)
+                result["latest_commit_date"].notna() & (result["latest_commit_date"] >= start)
             ]
         if end is not None:
             result = result[result["latest_commit_date"] <= end]


### PR DESCRIPTION
Decision: Harden the Release Copilot CI pipeline so linting, typing, and coverage drift are blocked before packaging jobs.
Note: Conftest now normalizes the repo root/src ordering so the `config` package exposes both `settings` and the shared loader without per-test path shims.
Action: Added a shared lint/format/type configuration, coverage gate script, workflow updates, and docs/runbook guidance for the stricter quality bar.

## Summary
- add `pyproject.toml` with Black/Ruff alignment (100 col, py311) and extend pre-commit with detect-private-key
- update pytest configuration and tests/conftest.py to centralize config stubs, block sockets, and avoid per-test sys.path hacks
- rewrite the CI workflow to run Ruff, Black, mypy, pytest with coverage, and the new `scripts/ci/coverage_gate.py` gate
- refresh README, runbooks, and CHANGELOG with the new workflow commands and import hygiene policies
- apply Black/Ruff formatting across the Python codebase so the stricter gates pass without follow-up churn

## Testing
- `ruff check .`
- `black --check .`
- `mypy --config-file mypy.ini -p releasecopilot`
- `pytest --cov=src --cov-report=xml`
- `scripts/ci/coverage_gate.py coverage.xml`


------
https://chatgpt.com/codex/tasks/task_e_68f28d626b68832fbb15b1349f13d1ab