### PR TITLE
Ensure CI removes Python caches before pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
       - name: Run mypy
         run: poetry run mypy .
 
+      - name: Clean Python caches
+        run: |
+          rm -rf .mypy_cache .pytest_cache
+          find . -path './.venv' -prune -o -name '__pycache__' -type d -exec rm -rf '{}' +
+
       - name: Determine coverage scope
         run: |
           set -eo pipefail


### PR DESCRIPTION
## Summary
- add an explicit cache cleanup step to the quality job to remove mypy, pytest, and __pycache__ artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffcaa760d8832f943c5cc73f26ab74