### PR TITLE
fix: ensure ci uses poetry env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install poetry==1.8.3
+          python -m pip install --upgrade pip
+          python -m pip install poetry==1.8.3
           poetry --version
 
       - name: Configure Poetry (no venv in-project)
@@ -24,6 +25,9 @@ jobs:
 
       - name: Install deps from lock
         run: poetry install --no-interaction --no-ansi --sync
+
+      - name: Pre-commit (all hooks)
+        run: poetry run pre-commit run --all-files
 
       - name: Ruff (lint)
         run: poetry run ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,14 +40,9 @@ repos:
     hooks:
       - id: check-generated-wave
         name: Check generated wave artifacts
-        entry: python -m tools.hooks.check_generator_drift
-        language: python
+        entry: bash -lc 'poetry run python tools/hooks/check_generator_drift.py'
+        language: system
         pass_filenames: false
-        additional_dependencies:
-          - click==8.1.7
-          - PyYAML==6.0.2
-          - Jinja2==3.1.0
-          - python-slugify==8.0.0
 ci:
   autofix_prs: true
   autofix_commit_msg: "chore(pre-commit): auto fixes from pre-commit.ci"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ explicit_package_bases = true
 namespace_packages = true
 ignore_missing_imports = true
 follow_imports = "silent"
+exclude = "(^rag-aws/)"
 warn_unused_configs = true
 warn_redundant_casts = true
 show_error_codes = true

--- a/src/releasecopilot/entrypoints/audit.py
+++ b/src/releasecopilot/entrypoints/audit.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
-import os
 from logging import Logger
+import os
 from pathlib import Path
 import shutil
 import subprocess

--- a/src/releasecopilot/entrypoints/audit.py
+++ b/src/releasecopilot/entrypoints/audit.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
-from logging import Logger
 import os
+from logging import Logger
 from pathlib import Path
 import shutil
 import subprocess
@@ -24,16 +24,6 @@ from zoneinfo import ZoneInfo
 
 import click
 
-LoadDotenvFn = Callable[..., bool]
-load_dotenv: LoadDotenvFn | None
-
-try:  # pragma: no cover - best effort optional dependency
-    from dotenv import load_dotenv as _load_dotenv
-except Exception:  # pragma: no cover - ignore missing dependency
-    load_dotenv = None
-else:
-    load_dotenv = _load_dotenv
-
 from cli.shared import AuditConfig, finalize_run, handle_dry_run, parse_args
 from clients.bitbucket_client import BitbucketClient
 from clients.jira_client import JiraClient, compute_fix_version_window
@@ -50,6 +40,16 @@ from releasecopilot.utils.jira_csv_loader import (
     load_issues_from_csv,
 )
 from tools.generator.generator import run_cli as run_generator_cli
+
+LoadDotenvFn = Callable[..., bool]
+load_dotenv: LoadDotenvFn | None
+
+try:  # pragma: no cover - best effort optional dependency
+    from dotenv import load_dotenv as _load_dotenv
+except Exception:  # pragma: no cover - ignore missing dependency
+    load_dotenv = None
+else:
+    load_dotenv = _load_dotenv
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 


### PR DESCRIPTION
## Summary
- reorder the audit entrypoint imports to satisfy Ruff E402 expectations
- run the check-generated-wave hook inside Poetry so releasecopilot imports resolve
- install Poetry via pip in CI, run hooks from the project virtualenv, and silence mypy's rag-aws duplicates

## Testing
- ❌ `poetry run pre-commit run --all-files` *(fails: Python 3.11.7 interpreter unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffd4261748832f89f6c46abc9c5b98