### PR TITLE
fix: restore cross-platform command for check-generated-wave hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: check-generated-wave
         name: Check generated wave artifacts
-        entry: bash -lc 'poetry run python tools/hooks/check_generator_drift.py'
+        entry: poetry run python tools/hooks/check_generator_drift.py
         language: system
         pass_filenames: false
 ci:


### PR DESCRIPTION
## Summary
- update the check-generated-wave pre-commit hook to invoke Poetry directly
- avoid relying on bash -lc so the hook runs on Windows setups without Bash

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffe5db5b74832f879b99987b94d496